### PR TITLE
Auth correctly 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,12 @@ Quickstart:
 Inspect the API:
 
     >>> import fritzconnection as fc
-    >>> fc.print_api(password='your_password')
+    >>> fc.print_api(address="fb_ipadress", user="username", password='your_password')
 
 An API-Call is made by the ``call_action``-method of the FritzConnection-Class. This method takes the ``servicename``, the ``actionname`` and optional arguments as parameter and may return a dictionary with the results (as described in the TR-064 protocoll description). A simple example is to reconnect for a new external ip:
 
     >>> from fritzconnection import FritzConnection
-    >>> connection = FritzConnection()
+    >>> connection = FritzConnection(address="fb_ipadress", user="usernam", password='passw')
     >>> connection.call_action('WANIPConnection', 'ForceTermination')
     # or more comfortable:
     >>> connection.reconnect()

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Inspect the API:
 An API-Call is made by the ``call_action``-method of the FritzConnection-Class. This method takes the ``servicename``, the ``actionname`` and optional arguments as parameter and may return a dictionary with the results (as described in the TR-064 protocoll description). A simple example is to reconnect for a new external ip:
 
     >>> from fritzconnection import FritzConnection
-    >>> connection = FritzConnection(address="fb_ipadress", user="usernam", password='passw')
+    >>> connection = FritzConnection(address="fb_ipadress", user="usernam", password='your_password')
     >>> connection.call_action('WANIPConnection', 'ForceTermination')
     # or more comfortable:
     >>> connection.reconnect()


### PR DESCRIPTION
- Auth Correctly. The Example shows only unauthenticated access, otherwise, It will not print all API methods. 
If you use multiple fritzboxes it may connect to the wrong one.

- Without Outh in the FritzConnection init it will return an Error.