### PR TITLE
added TLS support using a shared requests session;

### DIFF
--- a/fritzconnection/core/devices.py
+++ b/fritzconnection/core/devices.py
@@ -18,10 +18,12 @@ class DeviceManager:
     available services. Takes an optional `timeout` parameter to limit the time waiting for a router response.
     """
 
-    def __init__(self, timeout=None):
+    def __init__(self, timeout=None, certificate=None, session=None):
         self.descriptions = []
         self.services = {}
         self.timeout = timeout
+        self.certificate = certificate
+        self.session = session
 
     @property
     def modelname(self):
@@ -53,7 +55,7 @@ class DeviceManager:
         services. 'source' is a string with the xml-data, like the
         content of an igddesc- or tr64desc-file.
         """
-        root = get_xml_root(source, timeout=self.timeout)
+        root = get_xml_root(source, timeout=self.timeout, certificate=self.certificate, session=self.session)
         self.descriptions.append(Description(root))
 
     def scan(self):
@@ -64,11 +66,11 @@ class DeviceManager:
         for description in self.descriptions:
             self.services.update(description.services)
 
-    def load_service_descriptions(self, address, port):
+    def load_service_descriptions(self, address, protocol, port):
         """
         Triggers the load of the scpd files of the services, so they
         known their actions.
         """
         for service in self.services.values():
-            service.load_scpd(address, port, timeout=self.timeout)
+            service.load_scpd(address, protocol, port, timeout=self.timeout, certificate=self.certificate, session=self.session)
 

--- a/fritzconnection/core/processor.py
+++ b/fritzconnection/core/processor.py
@@ -326,11 +326,10 @@ class Service:
             self._state_variables = self._scpd.state_variables
         return self._state_variables
 
-    def load_scpd(self, address, port, timeout=None):
+    def load_scpd(self, address, protocol, port, timeout=None, certificate=None, session=None):
         """Loads the scpd data"""
-        protocol = 'http'
         url = f'{protocol}://{address}:{port}{self.SCPDURL}'
-        root = get_xml_root(url, timeout=timeout)
+        root = get_xml_root(url, timeout=timeout, certificate=certificate, session=session)
         self._scpd = Scpd(root)
 
 

--- a/fritzconnection/lib/fritzcall.py
+++ b/fritzconnection/lib/fritzcall.py
@@ -53,10 +53,10 @@ class FritzCall:
     *port* the port to connect to, *user* the username, *password* the
     password.
     """
-    def __init__(self, fc=None, address=None, port=None,
-                       user=None, password=None):
+    def __init__(self, fc=None, address=None, port=None, protocol='http',
+                       user=None, password=None, certificate=None):
         if fc is None:
-            fc = FritzConnection(address, port, user, password)
+            fc = FritzConnection(address, port, protocol, certificate, user, password)
         self.fc = fc
         self.calls = None
 
@@ -67,7 +67,7 @@ class FritzCall:
             url += f'&days={days}'
         elif num:
             url += f'&max={num}'
-        root = get_xml_root(url)
+        root = get_xml_root(url, certificate=self.fc.certificate, session=self.fc.session)
         self.calls = CallCollection(root)
 
     def get_calls(self, calltype=ALL_CALL_TYPES, update=True,

--- a/fritzconnection/lib/fritzhomeauto.py
+++ b/fritzconnection/lib/fritzhomeauto.py
@@ -23,10 +23,10 @@ class FritzHomeAutomation:
     password.
     """
 
-    def __init__(self, fc=None, address=None, port=None,
+    def __init__(self, fc=None, address=None, port=None, protocol='http', certificate=None,
                  user=None, password=None):
         if fc is None:
-            fc = FritzConnection(address, port, user, password)
+            fc = FritzConnection(address, port, protocol, certificate, user, password)
         self.fc = fc
 
     def _action(self, actionname, *, arguments=None, **kwargs):

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -1,5 +1,5 @@
 """
-Modul to list the known hosts. Older versions of FritzOS lists only up
+Module to list the known hosts. Older versions of FritzOS lists only up
 to 16 entries. For newer versions this limitation is gone.
 """
 # This module is part of the FritzConnection package.
@@ -23,10 +23,11 @@ class FritzHosts:
     to connect to, *user* the username, *password* the password.
     """
 
-    def __init__(self, fc=None, address=None, port=None, user=None, password=None):
+    def __init__(self, fc=None, address=None, port=None, protocol='http',
+                       user=None, password=None, certificate=None):
         super().__init__()
         if fc is None:
-            fc = FritzConnection(address, port, user, password)
+            fc = FritzConnection(address, port, protocol, certificate, user, password)
         self.fc = fc
 
     def _action(self, actionname, **kwargs):

--- a/fritzconnection/lib/fritzphonebook.py
+++ b/fritzconnection/lib/fritzphonebook.py
@@ -32,10 +32,10 @@ class FritzPhonebook(object):
     *port* the port to connect to, *user* the username, *password* the
     password.
     """
-    def __init__(self, fc=None, address=None, port=None,
-                       user=None, password=None):
+    def __init__(self, fc=None, address=None, port=None, protocol='http',
+                       user=None, password=None, certificate=None):
         if fc is None:
-            fc = FritzConnection(address, port, user, password)
+            fc = FritzConnection(address, port, protocol, certificate, user, password)
         self.fc = fc
         self.phonebook = None
 
@@ -125,7 +125,7 @@ class FritzPhonebook(object):
         method sets the phone book instance attribute and has no return
         value.
         """
-        root = get_xml_root(url)
+        root = get_xml_root(url, certificate=self.fc.certificate, session=self.fc.session)
         self.phonebook = Phonebook()
         process_node(self, root)
 

--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -19,13 +19,13 @@ class FritzStatus:
     the *port* of the Fritz!Box and the according *user* and *password*.
     """
 
-    def __init__(self, fc=None, address=None, port=None,
-                       user=None, password=None):
+    def __init__(self, fc=None, address=None, port=None, protocol='http',
+                       user=None, password=None, certificate=None):
         """
         :fc: instance of FritzConnection.
         :address: ip of the Fritz!Box
         """
-        self.fc = fc if fc else FritzConnection(address, port, user, password)
+        self.fc = fc if fc else FritzConnection(address, port, protocol, certificate, user, password)
         # depending on the model (i.e. a repeater) some services
         # may not be available. Don't let FritzStatus crash at init.
         try:
@@ -171,7 +171,7 @@ class FritzStatus:
         upstream, downstream = self.max_linked_bit_rate
         return (
             format_rate(upstream, unit='bits'),
-            format_rate(downstream, unit ='bits')
+            format_rate(downstream, unit='bits')
         )
 
     @property
@@ -184,7 +184,7 @@ class FritzStatus:
         upstream, downstream = self.max_bit_rate
         return (
             format_rate(upstream, unit='bits'),
-            format_rate(downstream, unit ='bits')
+            format_rate(downstream, unit='bits')
         )
 
     def reconnect(self):

--- a/fritzconnection/lib/fritzwlan.py
+++ b/fritzconnection/lib/fritzwlan.py
@@ -27,10 +27,10 @@ class FritzWLAN:
     standards.
     """
 
-    def __init__(self, fc=None, address=None, port=None,
-                       user=None, password=None, service=1):
+    def __init__(self, fc=None, address=None, port=None, protocol='http',
+                       user=None, password=None, certificate=None, service=1):
         if fc is None:
-            fc = FritzConnection(address, port, user, password)
+            fc = FritzConnection(address, port, protocol, certificate, user, password)
         self.fc = fc
         self.service = service
 


### PR DESCRIPTION
Hello,

Thank you very much for sharing this Python module which makes the communication with FritzBox devices much easier.

I added TLS support to the module to prevent passwords being sent without encryption through the network which might not always be safe. 
Since the FritzBox currently creates just self-signed certificates I decided to use certificate pinning where you first download the certificate from the FritzBox (e.g. by using the browser) and check against this certificate to prevent man-in-the-middle attacks. Nevertheless, it is also possible to disable certificate verification at all while still using TLS. Usually the FritzBox doesn't create a certificate for its IP address in the LAN so hostname verification is disabled (compare https://github.com/urllib3/urllib3/issues/517). 
A requests session of a FritzConnection instance is shared to speed up the execution time especially of the TLS connections. The other classes are adapted to be able to pass the parameters.

I tried to do the changes in a way that the current function calls have not to be changed. I also didn't change the CLI tools, which should still be working. Nevertheless, some tests still have to be done but at least in my tests with my FritzBox it still worked like before.

## TLS with certificate verification (certificate can be downloaded e.g. with Firefox by accessing the TLS encrypted web interface of the FritzBox)
fc = FritzConnection(address='192.168.178.1', password='PASSWORD', protocol='https', certificate="certificate.pem")

## TLS without certificate verification (will cause warnings)
fc = FritzConnection(address='192.168.178.1', password='PASSWORD', protocol='https', certificate=False)

## regular behavior
fc = FritzConnection(address='192.168.178.1', password='PASSWORD')


Best regards,

Andreas