### PR TITLE
Use 64bit integer methods and internal rate calculation

### DIFF
--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -22,14 +22,6 @@ class FritzStatus(AbstractLibraryBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # depending on the model (i.e. a repeater) some services
-        # may not be available. Don't let FritzStatus crash at init.
-        try:
-            self.last_bytes_sent = self.bytes_sent
-            self.last_bytes_received = self.bytes_received
-        except FritzServiceError:
-            pass
-        self.last_traffic_call = time.time()
 
     @property
     def is_linked(self):
@@ -78,16 +70,16 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def bytes_sent(self):
         """Total number of send bytes."""
-        status = self.fc.call_action('WANCommonIFC',
-                                     'GetTotalBytesSent')
-        return status['NewTotalBytesSent']
+        status = self.fc.call_action('WANCommonIFC1',
+                                     'GetAddonInfos')
+        return int(status['NewX_AVM_DE_TotalBytesSent64'])
 
     @property
     def bytes_received(self):
         """Total number of received bytes."""
-        status = self.fc.call_action('WANCommonIFC',
-                                     'GetTotalBytesReceived')
-        return status['NewTotalBytesReceived']
+        status = self.fc.call_action('WANCommonIFC1',
+                                     'GetAddonInfos')
+        return int(status['NewX_AVM_DE_TotalBytesReceived64'])
 
     @property
     def transmission_rate(self):
@@ -95,15 +87,10 @@ class FritzStatus(AbstractLibraryBase):
         The upstream and downstream values as a tuple in bytes per
         second. Use this for periodical calling.
         """
-        sent = self.bytes_sent
-        received = self.bytes_received
-        traffic_call = time.time()
-        time_delta = traffic_call - self.last_traffic_call
-        upstream = int(1.0 * (sent - self.last_bytes_sent)/time_delta)
-        downstream = int(1.0 * (received - self.last_bytes_received)/time_delta)
-        self.last_bytes_sent = sent
-        self.last_bytes_received = received
-        self.last_traffic_call = traffic_call
+        status = self.fc.call_action('WANCommonIFC1',
+                                     'GetAddonInfos')
+        upstream = status['NewByteSendRate']
+        downstream = status['NewByteReceiveRate']
         return upstream, downstream
 
     @property


### PR DESCRIPTION
The problem with the previous methods for getting the total byte counts is that it would overflow too often.
Overflowing is a lot less likely with 64bit integers.
Also, this changes the transmission rate calculation or rather it removes it and uses the values provided by the fritzbox directly.

I tested this in my own network and it seems to work just fine.

This should also fix #20.