### PR TITLE
exclude test files from packaged files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as file:
 setup(
     name = 'fritzconnection',
     version = package_version,
-    packages = find_packages(),
+    packages = find_packages(exclude=['*.tests']),
     license = 'MIT',
     description = 'Communicate with the AVM FRITZ!Box',
     long_description = the_long_description,


### PR DESCRIPTION
Hey there. Thanks for your work on this package!

I've been updating the NixOS packaging, and noticed that the `setup.py` file included the test files in the build. That's very likely not intentional, and also causes trouble because the tests refer to the xml directory in the source tree, which isn't packaged. They also cause weird `ImportMismatchError` with pytest.