### PR TITLE
Add connected_since property

### DIFF
--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -3,6 +3,7 @@ Modul to read status-informations from an AVM FritzBox.
 """
 
 import time
+import datetime
 
 from ..core.exceptions import FritzServiceError
 from .fritzbase import AbstractLibraryBase
@@ -74,6 +75,12 @@ class FritzStatus(AbstractLibraryBase):
         mins, secs = divmod(self.uptime, 60)
         hours, mins = divmod(mins, 60)
         return '%02d:%02d:%02d' % (hours, mins, secs)
+
+    @property
+    def connected_since(self):
+        """Last reconnect of WAN"""
+        time = datetime.datetime.now() - datetime.timedelta(seconds=self.uptime)
+        return time.strftime("%Y-%m-%d %H:%M")
 
     @property
     def bytes_sent(self):


### PR DESCRIPTION
I just added a connected_since property. I think there is no other way to get this value, than calculating it.

It will help to resolve the issues [#93](https://github.com/mammuth/ha-fritzbox-tools/issues/93) and [#35](https://github.com/mammuth/ha-fritzbox-tools/issues/35) of https://github.com/mammuth/ha-fritzbox-tools

I didn't include the seconds, because the time offset from the client and fritzbox will make it inaccurate.

Do you need more information for this pull request?