### PR TITLE
Enable auth for DeviceManager

### DIFF
--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -10,6 +10,7 @@ Module to communicate with the AVM Fritz!Box.
 import os
 import string
 import requests
+from requests.auth import HTTPDigestAuth
 
 from .devices import DeviceManager
 from .exceptions import (
@@ -97,6 +98,8 @@ class FritzConnection:
         session = requests.Session()
         session.verify = False
         session.timeout = timeout
+        if password:
+            session.auth = HTTPDigestAuth(user, password)
         # store as instance attributes for use by library modules
         self.address = address
         self.session = session


### PR DESCRIPTION
During the initilization of a FritzConnection a DeviceManager object is created with the session of the FritzConnection but this session doesn't contain the authentification data of the FritzConnection.

So for a connection using a address of the form `my-fritzbox-id.myfritz.net` and a port of the form `my-port/tr064` the connection fails.

After applying the changes of this pull request the connection can be established and calling `call_action` works.