### PR TITLE
Add get_host_name method

### DIFF
--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -148,6 +148,19 @@ class FritzHosts(AbstractLibraryBase):
         }
         self._action('X_AVM-DE_SetHostNameByMACAddress', arguments=args)
 
+    def get_host_name(self, mac_address):
+        """
+        Returns a String with the host_name of the device with the given mac_address
+        """
+        host = list
+        try:
+            host = self.get_specific_host_entry(mac_address)
+        except:
+            host = {
+                'NewHostName': 'Error' # fix this problem --> if the router mac is transferd i got an error with specific host entry method
+            }
+        return host['NewHostName']
+
     def run_host_update(self, mac_address):
         """
         Triggers the host with the given `mac_address` to run a system

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -152,14 +152,7 @@ class FritzHosts(AbstractLibraryBase):
         """
         Returns a String with the host_name of the device with the given mac_address
         """
-        host = list
-        try:
-            host = self.get_specific_host_entry(mac_address)
-        except:
-            host = {
-                'NewHostName': 'Error' # fix this problem --> if the router mac is transferd i got an error with specific host entry method
-            }
-        return host['NewHostName']
+        return self.get_specific_host_entry(mac_address)['NewHostName']
 
     def run_host_update(self, mac_address):
         """


### PR DESCRIPTION
Add get_host_name method for easy access of the device name.

Known Issues:
Sometimes get_specifiy_host_entry returns nothing and host is empty, but this occurred only when the repeaters mac was checked.
But I already created an issue ( #74 ) because of some problems with repeaters.  