### PR TITLE
FritzHosts - get_mesh_topology: catch exception when using repeater

### DIFF
--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -9,6 +9,7 @@ Modul to access and control the known hosts.
 
 import itertools
 from ..core.exceptions import (
+    FritzActionError,
     FritzArgumentError,
     FritzLookUpError,
 )
@@ -114,7 +115,8 @@ class FritzHosts(AbstractLibraryBase):
         url = f"{self.fc.address}:{self.fc.port}{path}"
         with self.fc.session.get(url) as response:
             if not response.ok:
-                return
+                message = f"Error {response.status_code}: Device has no access to topology information."
+                raise FritzActionError(message)
             return response.text if raw else response.json()
 
     def get_wakeonlan_status(self, mac_address):

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -113,6 +113,8 @@ class FritzHosts(AbstractLibraryBase):
         path = result["NewX_AVM-DE_MeshListPath"]
         url = f"{self.fc.address}:{self.fc.port}{path}"
         with self.fc.session.get(url) as response:
+            if not response.ok:
+                return
             return response.text if raw else response.json()
 
     def get_wakeonlan_status(self, mac_address):


### PR DESCRIPTION
Repeaters do not have access to meshlist.lua. In the current implementation of fritzhosts we would therefore get a `JSONDecodeError` when using `get_mesh_topology` on a repeater. 

This PR catches the 404 error and returns None.