### PR TITLE
add mesh properties to host info

### DIFF
--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -8,6 +8,7 @@ Modul to access and control the known hosts.
 
 
 import itertools
+from typing import Tuple
 from ..core.exceptions import (
     FritzActionError,
     FritzArgumentError,
@@ -17,17 +18,16 @@ from .fritzbase import AbstractLibraryBase
 
 
 SERVICE = "Hosts1"
-
+KNOWN_MESHROLES = ["master", "slave"]
 
 def _get_mesh_by_mac(topology, mac):
-    if topology is None:
-        return None, None
-
     for node in topology["nodes"]:
         if node["device_mac_address"] == mac:
-            return node["is_meshed"], node["mesh_role"]
+            mesh_role: str = node["mesh_role"] if node["mesh_role"] in KNOWN_MESHROLES else "None"
+            is_meshed: bool = node["is_meshed"]
+            return is_meshed, mesh_role
 
-    return None, None
+    return False, "None"
 
 
 class FritzHosts(AbstractLibraryBase):

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -133,15 +133,19 @@ class FritzHosts(AbstractLibraryBase):
         In case no topology information is available an empty dictionary gets
         returned.
         """
+        mesh_info = {}
         if topology is None:
             try:
                 topology = self.get_mesh_topology()
             except FritzActionError:
-                return {}
-        return {
-            node["device_mac_address"]: (node["is_meshed"], node["mesh_role"])
-            for node in topology["nodes"]
-        }
+                return mesh_info
+
+        for node in topology["nodes"]:
+            mac_adresses = [interface["mac_address"] for interface in node["node_interfaces"]]
+            for mac in mac_adresses:
+                mesh_info[mac] = (node["is_meshed"], node["mesh_role"])
+
+        return mesh_info
 
     def get_wakeonlan_status(self, mac_address):
         """

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -8,7 +8,6 @@ Modul to access and control the known hosts.
 
 
 import itertools
-from typing import Tuple
 from ..core.exceptions import (
     FritzActionError,
     FritzArgumentError,
@@ -18,6 +17,7 @@ from .fritzbase import AbstractLibraryBase
 
 
 SERVICE = "Hosts1"
+
 
 class FritzHosts(AbstractLibraryBase):
     """

--- a/fritzconnection/tests/test_fritzhosts.py
+++ b/fritzconnection/tests/test_fritzhosts.py
@@ -17,8 +17,20 @@ def mesh_topology_fixture():
                 'is_meshed': True,
                 'mesh_role': 'master',
                 'meshd_version': '2.25',
-                'node_interfaces': []
-               }]}
+                'node_interfaces': [{'uid': 'ni-237',
+                    'name': 'AP:2G:0',
+                    'type': 'WLAN',
+                    'mac_address': '12:12:12:12:12:12',
+                    'blocking_state': 'UNKNOWN',
+                    'node_links': []},
+                   {'uid': 'ni-236',
+                    'name': 'LANBridge',
+                    'type': 'LAN',
+                    'mac_address': '11:11:11:11:11:11',
+                    'blocking_state': 'UNKNOWN',
+                    'node_links': []}]
+                }],
+            }
 
 
 def test_get_mesh_topology_info(mesh_topology_fixture):

--- a/fritzconnection/tests/test_fritzhosts.py
+++ b/fritzconnection/tests/test_fritzhosts.py
@@ -1,0 +1,35 @@
+import pytest
+
+from ..lib.fritzhosts import (
+    FritzHosts,
+)
+
+
+@pytest.fixture()
+def mesh_topology_fixture():
+    return {'schema_version': '1.9',
+            'nodes': [{'uid': 'n-1',
+                'device_name': 'fritz.box',
+                'device_model': 'FRITZ!Box Model',
+                'device_manufacturer': 'AVM',
+                'device_firmware_version': '111.11.11',
+                'device_mac_address': '11:11:11:11:11:11',
+                'is_meshed': True,
+                'mesh_role': 'master',
+                'meshd_version': '2.25',
+                'node_interfaces': []
+               }]}
+
+
+def test_get_mesh_topology_info(mesh_topology_fixture):
+    """
+    Simple test of the topology_info function.
+    """
+    host = FritzHosts()
+    result = host.get_mesh_topology_info(topology=mesh_topology_fixture)
+    node = mesh_topology_fixture['nodes'][0]
+    assert result[node['device_mac_address']] == (node['is_meshed'], node['mesh_role'])
+
+    # Return empty result upon FritzActionError:
+    empty_result = host.get_mesh_topology_info(topology=None)
+    assert empty_result == {}


### PR DESCRIPTION
Add mesh info to `get_hosts_info`.
Note: Mac adresses do not match between `get_specific_host_entry` and `get_mesh_topology`.
I am not sure if there is a work around it.