### PR TITLE
Include DSL line errors into the status

### DIFF
--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -288,3 +288,86 @@ class FritzStatus(AbstractLibraryBase):
         upstream, downstream = self.attenuation
         return (format_dB(upstream), format_dB(downstream))
 
+    @property
+    def error_secs(self):
+        """
+        Number of seconds with errors on the DSL line.
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        return status["NewErroredSecs"]
+
+    @property
+    def error_secs_severe(self):
+        """
+        Number of seconds with severe errors on the DSL line impacting speed/reliability. 
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        return status["NewSeverelyErroredSecs"]
+
+    @property
+    def error_LOF(self):
+        """
+        Number of LOF (loss of frame) errors. During this burst error all packages were lost.
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        return status["NewLossOfFraming"]
+
+    @property
+    def error_FEC(self):
+        """
+        Tuple of DSL FEC line errors (corrected). No new package was requested. First item
+        is upstream, second item downstream.
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        upstream = status["NewATUCFECErrors"]
+        downstream = status["NewFECErrors"]
+        return upstream, downstream
+
+    @property
+    def str_error_FEC(self):
+        """
+        Human readable number of DSL FEC line errors. Value is a tuple, first item
+        is upstream, second item downstream.
+        """
+        upstream, downstream = self.error_FEC
+        return upstream, downstream
+
+    @property
+    def error_CRC(self):
+        """
+        Tuple of DSL CRC line errors (non corrected). Package had to be re requested. First item
+        is upstream, second item downstream.
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        upstream = status["NewATUCCRCErrors"]
+        downstream = status["NewCRCErrors"]
+        return upstream, downstream
+
+    @property
+    def str_error_CRC(self):
+        """
+        Human readable number of DSL CRC line errors. Value is a tuple, first item
+        is upstream, second item downstream.
+        """
+        upstream, downstream = self.error_FEC
+        return upstream, downstream
+
+    @property
+    def error_HEC(self):
+        """
+        Tuple of DSL HEC line errors (header errors). Package had to be retransmitted from ATU. First item
+        is upstream, second item downstream.
+        """
+        status = self.fc.call_action('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
+        upstream = status["NewATUCHECErrors"]
+        downstream = status["NewHECErrors"]
+        return upstream, downstream
+
+    @property
+    def str_error_HEC(self):
+        """
+        Human readable number of DSL HEC line errors. Value is a tuple, first item
+        is upstream, second item downstream.
+        """
+        upstream, downstream = self.error_FEC
+        return upstream, downstream


### PR DESCRIPTION
This CR adds the values for LOF, FEC, CRC and HEC as well as the information about error seconds to fritzstatus. 
All new values start with the error or str_error prefix. 
This information is similar to the errors tab in the fritzbox interface. Together with the already implemented noise_margin and attenuation this allows for complete monitoring of the DSL line quality.

Some Additional information:
Errors greatly impact the DSL performance. Some (rare) errors are normal, but an increased error number indicates a problem with the DSL line itself.
LOF errors means line went down foa a sort period of time, but did not requiring a resync
FEC errors could be corrected in the router with the additional Forward Error Correction information
CRC errors could not be corrected by the router. The IP packages were lost and have to be retransmitted.  
HEC The header information did not match the data. The DSL frame had to be retransmitted by the ATU

The effective line speed is reduced due to LOF, CRC and HEC errors (but not FEC). 
Additionally UDP packages might be lost for CRC and LOF errors, e.g. resulting in blocky video streams.