### PR TITLE
Change default logging level from DEBUG to INFO

### DIFF
--- a/fritzconnection/core/logger.py
+++ b/fritzconnection/core/logger.py
@@ -47,7 +47,7 @@ class FritzLogger:
             cls._instance = super().__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def __init__(self, level=logging.DEBUG):
+    def __init__(self, level=logging.INFO):
         """Creates the internal logger state."""
         self.logger = logging.getLogger("fritzconnection")
         self.logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
Default logging level should be less aggressive.
Many external tools, like Home Assistant, rely on library default and doesn't force a different level if not explicitly requested.

When a debug session is requested, only in that moment logging level should be changed.

Simone