### PR TITLE
Additional host attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/_build/*
 fritzconnection.egg-info/*
 include
 lib_
+.idea

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -77,14 +77,14 @@ class FritzHosts(AbstractLibraryBase):
     def get_active_hosts(self):
         """
         Returns a list of dicts with information about the active
-        devices. The dict-keys are: 'ip', 'name', 'mac', 'status'
+        devices. The dict-keys are: 'ip', 'name', 'mac', 'status', 'interfaceType', 'addressSource', 'leaseTimeRemaining'
         """
         return [host for host in self.get_hosts_info() if host["status"]]
 
     def get_hosts_info(self):
         """
         Returns a list of dicts with information about the known hosts.
-        The dict-keys are: 'ip', 'name', 'mac', 'status'
+        The dict-keys are: 'ip', 'name', 'mac', 'status', 'interfaceType', 'addressSource', 'leaseTimeRemaining'
         """
         result = []
         for index in itertools.count():
@@ -99,6 +99,9 @@ class FritzHosts(AbstractLibraryBase):
                     "name": host["NewHostName"],
                     "mac": host["NewMACAddress"],
                     "status": host["NewActive"],
+                    "interfaceType": host["NewInterfaceType"],
+                    "addressSource": host["NewAddressSource"],
+                    "leaseTimeRemaining": host["NewLeaseTimeRemaining"],
                 }
             )
         return result

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -77,14 +77,14 @@ class FritzHosts(AbstractLibraryBase):
     def get_active_hosts(self):
         """
         Returns a list of dicts with information about the active
-        devices. The dict-keys are: 'ip', 'name', 'mac', 'status', 'interfaceType', 'addressSource', 'leaseTimeRemaining'
+        devices. The dict-keys are: 'ip', 'name', 'mac', 'status', 'interface_type', 'address_source', 'lease_time_remaining'
         """
         return [host for host in self.get_hosts_info() if host["status"]]
 
     def get_hosts_info(self):
         """
         Returns a list of dicts with information about the known hosts.
-        The dict-keys are: 'ip', 'name', 'mac', 'status', 'interfaceType', 'addressSource', 'leaseTimeRemaining'
+        The dict-keys are: 'ip', 'name', 'mac', 'status', 'interface_type', 'address_source', 'lease_time_remaining'
         """
         result = []
         for index in itertools.count():
@@ -99,9 +99,9 @@ class FritzHosts(AbstractLibraryBase):
                     "name": host["NewHostName"],
                     "mac": host["NewMACAddress"],
                     "status": host["NewActive"],
-                    "interfaceType": host["NewInterfaceType"],
-                    "addressSource": host["NewAddressSource"],
-                    "leaseTimeRemaining": host["NewLeaseTimeRemaining"],
+                    "interface_type": host["NewInterfaceType"],
+                    "address_source": host["NewAddressSource"],
+                    "lease_time_remaining": host["NewLeaseTimeRemaining"],
                 }
             )
         return result


### PR DESCRIPTION
Fetches additional host attributes and adds them to the returned dictionary:

* NewAddressSource
* NewLeaseTimeRemaining
* NewInterfaceType

Especially the "Interface Type" is interesting, since it will show if the host is connected via wire or has a wireless connection ("Ethernet", "802.11").