### PR TITLE
Orthographic improvements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ fritzconnection documentation
 =============================
 
 
-fritzconnection is a `Python <https://www.python.org/>`_ library to communicate with the `AVM Fritz!Box <https://en.avm.de/produkte/fritzbox/>`_ by the TR-064 protocol. This allows to read status-informations from the box and to read and change configuration settings and state. Also realtime phone call monitoring is provided.
+fritzconnection is a `Python <https://www.python.org/>`_ library to communicate with the `AVM Fritz!Box <https://en.avm.de/produkte/fritzbox/>`_ by the TR-064 protocol. This allows to read status-information from the box and to read and change configuration settings and state. Also realtime phone call monitoring is provided.
 
 .. image:: fritzconnection-360x76.png
 
@@ -18,7 +18,7 @@ The available services are depending on the Fritz!Box model and the according sy
 
     fc = FritzConnection(address='192.168.178.1')
     fc.reconnect()  # get a new external ip from the provider
-    print(fc)  # print router model informations
+    print(fc)  # print router model information
 
 The *reconnect()* method wraps the ``call_action()`` method. A reconnection by means of ``call_action()`` would look like this: ::
 
@@ -27,7 +27,7 @@ The *reconnect()* method wraps the ``call_action()`` method. A reconnection by m
 
 With the ``call_action()`` method every service/action combination documented by the `AVM support-page (Apps/TR-064) <https://avm.de/service/schnittstellen/>`_ can get executed. For more information refer to `Introduction <sources/introduction.html>`_.
 
-fritzconnection comes with a `library <sources/library.html>`_ to make some common tasks easier and to serve as examples how to use fritzconnection. The library also provides a fritzmonitor module for accessing the call-monitor interface of the Fritz!Box to get realtime informations about incoming and outgoing phone calls: ::
+fritzconnection comes with a `library <sources/library.html>`_ to make some common tasks easier and to serve as examples how to use fritzconnection. The library also provides a fritzmonitor module for accessing the call-monitor interface of the Fritz!Box to get realtime information about incoming and outgoing phone calls: ::
 
    from fritzconnection import FritzMonitor
 

--- a/docs/sources/authors.rst
+++ b/docs/sources/authors.rst
@@ -15,5 +15,5 @@ Additional authors having contributed to this project:
 * Julian Tatsch
 
 
-Since moving from bitbucket to github, an up to date list of contributers is listed here: `https://github.com/kbr/fritzconnection/graphs/contributors <https://github.com/kbr/fritzconnection/graphs/contributors>`_.
+Since moving from bitbucket to github, an up to date list of contributors is listed here: `https://github.com/kbr/fritzconnection/graphs/contributors <https://github.com/kbr/fritzconnection/graphs/contributors>`_.
 

--- a/docs/sources/call_monitoring.rst
+++ b/docs/sources/call_monitoring.rst
@@ -2,7 +2,7 @@
 Call Monitoring
 ---------------
 
-The fritzmonitor-module is a core module of fritzconnection to provide real-time informations about incoming and outgoing phone-calls. This functionality is based on a separate socket-connection to the router and does not communicate by TR-064. 
+The fritzmonitor-module is a core module of fritzconnection to provide real-time information about incoming and outgoing phone-calls. This functionality is based on a separate socket-connection to the router and does not communicate by TR-064.
 
 FritzMonitor provides a queue of type ``queue.Queue`` for accessing CallMonitor events. To check the events send from the router, fritzconnection comes with a ``fritzmonitor`` command line tool. The next block shows a typical session: ::
 

--- a/docs/sources/changes.rst
+++ b/docs/sources/changes.rst
@@ -14,7 +14,7 @@ Version History
   - The methods `get_active_hosts` and `get_hosts_info` provide additional host attributes (#127)
 
 - Refactoring of the logging module `fritzconnection.core.logger` (introduced in 1.7.0). Now emitting messages from INFO-level and up by default.
-- Connection errors with the router raised from the underlying `urllib3` library are catched and raised again as FritzConnectionException preserving the connection error information (#128)
+- Connection errors with the router raised from the underlying `urllib3` library are caught and raised again as FritzConnectionException preserving the connection error information (#128)
 
 
 1.7.2

--- a/docs/sources/changes.rst
+++ b/docs/sources/changes.rst
@@ -14,7 +14,7 @@ Version History
   - The methods `get_active_hosts` and `get_hosts_info` provide additional host attributes (#127)
 
 - Refactoring of the logging module `fritzconnection.core.logger` (introduced in 1.7.0). Now emitting messages from INFO-level and up by default.
-- Connection errors with the router raised from the underlying `urllib3` library are catched and raised again as FritzConnectionException preserving the connection error informations (#128)
+- Connection errors with the router raised from the underlying `urllib3` library are catched and raised again as FritzConnectionException preserving the connection error information (#128)
 
 
 1.7.2
@@ -112,7 +112,7 @@ Version History
 -----
 
 - Library class FritzStatus reports the sent and received bytes now as 64 bit integers and provides easy access to realtime monitor data.
-- Library class FritzHost provides more methods to access devices, including *wake on LAN* and net topology informations.
+- Library class FritzHost provides more methods to access devices, including *wake on LAN* and net topology information.
 - Library class FritzPhonebook has a new method *get_all_name_numbers()* to fix a bug of *get_all_names()* reporting just one name in case that a phonebook holds multiple entries of the same name.
 - Boolean arguments send to the router as *1* and *0* can also be given as the Python datatypes *True* and *False* (#30).
 - Flag -c added to fritzconnection cli interface to report the complete api.
@@ -229,7 +229,7 @@ Bugfixes, no new features or other changes.
 
 FritzConnection does now check for the environment variables ``FRITZ_USER`` and ``FRITZ_PASSWORD`` in case that neither user nor password are given.
 
-FritzStatus now accepts user and password as keyword-parameters. Keep in mind, that FritzBoxes may return different informations about the status depending whether these are gathered with or without a password.
+FritzStatus now accepts user and password as keyword-parameters. Keep in mind, that FritzBoxes may return different information about the status depending whether these are gathered with or without a password.
 
 
 0.6.5

--- a/docs/sources/further_reading.rst
+++ b/docs/sources/further_reading.rst
@@ -4,6 +4,6 @@ Further Reading
 ===============
 
 
-Information about the TR-064 protocol with services and actions as well as AVM-specific extensions are listet at the `AVM support-page <https://avm.de/service/schnittstellen/>`_ (at present in german language only).
+Information about the TR-064 protocol with services and actions as well as AVM-specific extensions are listed at the `AVM support-page <https://avm.de/service/schnittstellen/>`_ (at present in german language only).
 
 

--- a/docs/sources/further_reading.rst
+++ b/docs/sources/further_reading.rst
@@ -4,6 +4,6 @@ Further Reading
 ===============
 
 
-Informations about the TR-064 protocol with services and actions as well as AVM-specific extensions are listet at the `AVM support-page <https://avm.de/service/schnittstellen/>`_ (at present in german language only).
+Information about the TR-064 protocol with services and actions as well as AVM-specific extensions are listet at the `AVM support-page <https://avm.de/service/schnittstellen/>`_ (at present in german language only).
 
 

--- a/docs/sources/introduction.rst
+++ b/docs/sources/introduction.rst
@@ -31,7 +31,7 @@ The ip-adress is a fallback-value common to every fritzbox-router, regardless of
 Usernames and passwords
 -----------------------
 
-For some operations a username and/or a password is required. This can be given on the command line as parameters or, by using a module, as arguments. To not present these informations in clear text, username and password can get stored in the environment variables ``FRITZ_USERNAME`` and ``FRITZ_PASSWORD``. FritzConnection will check for these environment variables first and, if set, will use the corresponding values.
+For some operations a username and/or a password is required. This can be given on the command line as parameters or, by using a module, as arguments. To not present these information in clear text, username and password can get stored in the environment variables ``FRITZ_USERNAME`` and ``FRITZ_PASSWORD``. FritzConnection will check for these environment variables first and, if set, will use the corresponding values.
 
 For Fritz!OS < 7.24 the username was optional and a default username gets used in this case. For newer versions an individual username is required. If a username is not provided, FritzConnection will read the username of the last logged in user from the Fritz!Box and will take this username as default.
 
@@ -239,9 +239,9 @@ The result of calling the ``call_action`` method is always a dictionary with the
      'NewStandard': 'n',
      'NewStatus': 'Up'}
 
-These informations are showing a lot of details about the WLAN configuration. In this example the network is up and operating on channel 6.
+This information is showing a lot of details about the WLAN configuration. In this example the network is up and operating on channel 6.
 
-To activate or deactivate a network, the action ``SetEnable`` can get called. Inspection gives informations about the required arguments: ::
+To activate or deactivate a network, the action ``SetEnable`` can get called. Inspection gives information about the required arguments: ::
 
     $ $ fritzconnection -i 192.168.178.1 -A WLANConfiguration1 SetEnable
 

--- a/docs/sources/library.rst
+++ b/docs/sources/library.rst
@@ -159,7 +159,7 @@ FritzHomeAutomation  API
 FritzHosts
 ----------
 
-Utility modul for FritzConnection to access and control the known hosts. The command line tool allows to list the current ip, name, the MAC address and the active-state for all registered hosts: ::
+Utility module for FritzConnection to access and control the known hosts. The command line tool allows to list the current ip, name, the MAC address and the active-state for all registered hosts: ::
 
     $ fritzhosts -i 192.168.178.1 -p <password>
 

--- a/docs/sources/library.rst
+++ b/docs/sources/library.rst
@@ -5,7 +5,7 @@ The library is a package with modules on top of FritzConnection to address speci
 
 **Performance considerations:**
 
-Creating a FritzConnection instance will inspect the Fritz!Box API to get information about all availabe services and corresponding actions. As this is i/o based it's generally slow. But once an instance is created, it can be reused for all tasks. Therefore the library classes can optionally initialised with an existing FritzConnection instance, to not inspect the router-API multiple times: ::
+Creating a FritzConnection instance will inspect the Fritz!Box API to get information about all available services and corresponding actions. As this is i/o based it's generally slow. But once an instance is created, it can be reused for all tasks. Therefore the library classes can optionally initialised with an existing FritzConnection instance, to not inspect the router-API multiple times: ::
 
     from fritzconnection import FritzConnection
     from fritzconnection.lib.fritzhomeauto import FritzHomeAutomation
@@ -146,7 +146,7 @@ It is also easy to toggle a switch (like a FRITZ!DECT 200/210 device): ::
 
     fha.set_switch(ain, on=True)
 
-This will turn the switch with the given identifier *on* or *off* depending whether the parameter 'on' is *True* or *False*. Usecases can be to set a switch depending on the temperature or daytime.
+This will turn the switch with the given identifier *on* or *off* depending whether the parameter 'on' is *True* or *False*. Use-cases can be to set a switch depending on the temperature or daytime.
 
 
 FritzHomeAutomation  API
@@ -316,7 +316,7 @@ Example to get the total number of known WLAN-devices for all WLANConfigurations
 Example: device tracking
 ........................
 
-A common usecase for wlan-information is device tracking. The following is a basic example how to do this. The example will poll the mac-addresses of all active devices. (For this a fixed tracking duration with a short poll-period is used. This may not be appropriate for real world programs.)
+A common use-case for wlan-information is device tracking. The following is a basic example how to do this. The example will poll the mac-addresses of all active devices. (For this a fixed tracking duration with a short poll-period is used. This may not be appropriate for real world programs.)
 ::
 
     import time

--- a/docs/sources/library.rst
+++ b/docs/sources/library.rst
@@ -5,7 +5,7 @@ The library is a package with modules on top of FritzConnection to address speci
 
 **Performance considerations:**
 
-Creating a FritzConnection instance will inspect the Fritz!Box API to get informations about all availabe services and corresponding actions. As this is i/o based it's generally slow. But once an instance is created, it can be reused for all tasks. Therefore the library classes can optionally initialised with an existing FritzConnection instance, to not inspect the router-API multiple times: ::
+Creating a FritzConnection instance will inspect the Fritz!Box API to get information about all availabe services and corresponding actions. As this is i/o based it's generally slow. But once an instance is created, it can be reused for all tasks. Therefore the library classes can optionally initialised with an existing FritzConnection instance, to not inspect the router-API multiple times: ::
 
     from fritzconnection import FritzConnection
     from fritzconnection.lib.fritzhomeauto import FritzHomeAutomation
@@ -105,19 +105,19 @@ Can access Homeautomation devices to read the current states and set the status 
     Device Name             AIN                 Power[W]   t[°C]   switch
     FRITZ!DECT 210 #1       '11657 0240192'        0.000    23.5   on
 
-The optional ``-v`` flag will give a verbose report about all device informations, including the settings of radiator controls.
+The optional ``-v`` flag will give a verbose report about all device information, including the settings of radiator controls.
 
 The ``-s`` flag can set the state of switches. This flag requires two parameters: the device identifier (AIN) and the state to set [on|off]. The following example will switch off the device with the identifier '11657 0240192': ::
 
     $ fritzhomeauto -i 192.168.178.1 -p <password> -s '11657 0240192' off
 
 
-Example on how to get informations about the known devices by using a module: ::
+Example on how to get information about the known devices by using a module: ::
 
     from fritzconnection.lib.fritzhomeauto import FritzHomeAutomation
 
     fha = FritzHomeAutomation(address='192.168.178.1', password=<password>)
-    info = fha.device_informations()
+    info = fha.device_information()
 
 'info' is a list of dictionaries describing the devices: ::
 
@@ -136,7 +136,7 @@ Example on how to get informations about the known devices by using a module: ::
       'NewTemperatureIsValid': 'VALID',
       'NewTemperatureOffset': 0}]
 
-Depending on the device, different informations will get reported. Informations about a specific device can get obtained with the identifier *NewAIN*. The next example shows how to get the temperature in °C, taken the *NewAIN* from device_informations() call: ::
+Depending on the device, different information will get reported. Information about a specific device can get obtained with the identifier *NewAIN*. The next example shows how to get the temperature in °C, taken the *NewAIN* from device_information() call: ::
 
     ain = '11657 0240192'
     fha.get_device_information_by_identifier(ain)['NewTemperatureCelsius'] * 0.1
@@ -241,7 +241,7 @@ FritzPhonebook API
 FritzStatus
 -----------
 
-Reports informations about the link-status to the service provider. Usage from the command line: ::
+Reports information about the link-status to the service provider. Usage from the command line: ::
 
     $ fritzstatus -i 192.168.178.1 -p password
 
@@ -316,7 +316,7 @@ Example to get the total number of known WLAN-devices for all WLANConfigurations
 Example: device tracking
 ........................
 
-A common usecase for wlan-informations is device tracking. The following is a basic example how to do this. The example will poll the mac-addresses of all active devices. (For this a fixed tracking duration with a short poll-period is used. This may not be appropriate for real world programs.)
+A common usecase for wlan-information is device tracking. The following is a basic example how to do this. The example will poll the mac-addresses of all active devices. (For this a fixed tracking duration with a short poll-period is used. This may not be appropriate for real world programs.)
 ::
 
     import time

--- a/fritzconnection/cli/fritzhomeauto.py
+++ b/fritzconnection/cli/fritzhomeauto.py
@@ -15,8 +15,8 @@ from . utils import get_cli_arguments, get_instance, print_header
 
 
 def report_verbose(fh):
-    informations = fh.device_informations()
-    for info in informations:
+    information = fh.device_information()
+    for info in information:
         width = len(max(info.keys(), key=lambda x: len(x)))
         line = f'{{attribute:{width}}} : {{value}}'
         for attribute in sorted(info.keys()):
@@ -31,7 +31,7 @@ def report_compact(fh):
     temperature = 't[°C]'
     switch_state = 'switch'
     print(f'{name:24}{ain:18}{power:>10}{temperature:>8}   {switch_state}')
-    for di in fh.device_informations():
+    for di in fh.device_information():
         name = di['NewDeviceName']
         ain = di['NewAIN']
         ain = f"'{ain}'"

--- a/fritzconnection/cli/fritzstatus.py
+++ b/fritzconnection/cli/fritzstatus.py
@@ -17,7 +17,7 @@ from .utils import get_cli_arguments, get_instance, print_header
 
 def print_status(fs):
     print("FritzStatus:\n")
-    status_informations = [
+    status_information = [
         ("is linked", "is_linked"),
         ("is connected", "is_connected"),
         ("external ip (v4)", "external_ip"),
@@ -28,7 +28,7 @@ def print_status(fs):
         ("bytes received", "bytes_received"),
         ("max. bit rate", "str_max_bit_rate"),
     ]
-    for status, attribute in status_informations:
+    for status, attribute in status_information:
         try:
             information = getattr(fs, attribute)
         except (FritzServiceError, FritzActionError):

--- a/fritzconnection/cli/fritzwlan.py
+++ b/fritzconnection/cli/fritzwlan.py
@@ -29,13 +29,13 @@ def get_header():
 
 def report_wlanconfiguration(fw, extension):
     fw.service = extension
-    host_informations = fw.get_hosts_info()
-    if host_informations:
+    hosts_info = fw.get_hosts_info()
+    if hosts_info:
         print(f'Hosts registered at {SERVICE}{extension}:')
         print(f'WLAN name: {fw.ssid}')
         print(f'channel  : {fw.channel}')
         print(get_header())
-        for info in host_informations:
+        for info in hosts_info:
             index = info['index']
             status = info['status']
             mac = info['mac']

--- a/fritzconnection/core/devices.py
+++ b/fritzconnection/core/devices.py
@@ -14,7 +14,7 @@ from .utils import get_xml_root
 
 class DeviceManager:
     """
-    Knows all data about the device and the subdevices, including the
+    Knows all data about the device and the sub-devices, including the
     available services. Takes an optional `timeout` parameter to limit
     the time waiting for a router response. The optional parameter
     `session` is a reusable connection and can speed up the

--- a/fritzconnection/core/devices.py
+++ b/fritzconnection/core/devices.py
@@ -43,7 +43,7 @@ class DeviceManager:
         """
         Returns the system-version as string with minor- and
         patch-level. This corresponds to the OS version reported by the
-        router web-interface. Returns None if no system informations are
+        router web-interface. Returns None if no system information is
         available.
         """
         version = None
@@ -57,7 +57,7 @@ class DeviceManager:
     def system_info(self):
         """
         Returns a tuple with Hardwarecode, Major-, Minor-, Patch-Level, Buildnumber and Display-String, in this order.
-        Return None if this informations are not available.
+        Return None if this information is not available.
         """
         system_info = None
         for description in self.descriptions:

--- a/fritzconnection/core/exceptions.py
+++ b/fritzconnection/core/exceptions.py
@@ -71,24 +71,24 @@ class FritzConnectionException(Exception):
 
 class ActionError(FritzConnectionException):
     """
-    Exception raised by calling nonexisting actions.
-    Legathy Exception. Use FritzActionError instead.
+    Exception raised by calling non-existing actions.
+    Legacy Exception. Use FritzActionError instead.
     """
 
 
 class ServiceError(FritzConnectionException):
     """
-    Exception raised by calling nonexisting services.
-    Legathy Exception. Use FritzServiceError instead.
+    Exception raised by calling non-existing services.
+    Legacy Exception. Use FritzServiceError instead.
     """
 
 
 class FritzServiceError(ServiceError):
-    """Exception raised by calling nonexisting services."""
+    """Exception raised by calling non-existing services."""
 
 
 class FritzActionError(ActionError):
-    """Exception raised by calling nonexisting actions."""
+    """Exception raised by calling non-existing actions."""
 
 
 class FritzResourceError(FritzConnectionException):

--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -94,7 +94,7 @@ class FritzConnection:
         Initialisation of FritzConnection: reads all data from the box
         and also the api-description (the servicenames and according
         actionnames as well as the parameter-types) that can vary among
-        models and stores these informations as instance-attributes.
+        models and stores the information as instance-attributes.
         This can be an expensive operation. Because of this an instance
         of FritzConnection should be created once and reused in an
         application. All parameters are optional. But if there is more

--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -51,7 +51,7 @@ class FritzConnection:
     Main class to set up a connection to the Fritz!Box router. All
     parameters are optional. `address` should be the ip of a router, in
     case that are multiple Fritz!Box routers in a network, the ip must
-    be given. Otherwise it is undefined which router will respond. If
+    be given. Otherwise, it is undefined which router will respond. If
     `user` and `password` are not provided, the environment gets checked for
     FRITZ_USERNAME and FRITZ_PASSWORD settings and taken from there, if
     found.
@@ -70,7 +70,7 @@ class FritzConnection:
     7.24 also requires a username, the previous default username is just
     valid for OS versions < 7.24. In case the username is not given and
     the system version is 7.24 or newer, FritzConnection uses the last
-    logged in username as default.
+    logged-in username as default.
     (`New in version 1.5`)
 
     For applications where the urllib3 default connection-pool size
@@ -264,7 +264,7 @@ class FritzConnection:
         keyword-parameters as further arguments are ignored.
         The argument values can be of type *str*, *int* or *bool*.
         (Note: *bool* is provided since 1.3. In former versions
-        booleans must provided as numeric values: 1, 0).
+        booleans must be provided as numeric values: 1, 0).
         If the service_name does not end with a number (like 1), a 1
         gets added by default. If the service_name ends with a colon and a
         number, the colon gets removed. So i.e. WLANConfiguration

--- a/fritzconnection/core/fritzmonitor.py
+++ b/fritzconnection/core/fritzmonitor.py
@@ -138,7 +138,7 @@ class FritzMonitor:
         stop() first. `queue_size` is the number of events the queue can store.
         If `block_on_filled_queue` is False the event will get discarded in case
         of no free block (default). On True the EventReporter will block until a
-        slot is awailable. `reconnect_delay` defines the maximum time intervall in
+        slot is available. `reconnect_delay` defines the maximum time interval in
         seconds between reconnection tries, in case that a socket-connection
         gets lost. `reconnect_tries` defines the number of consecutive to
         reconnect a socket before giving up.
@@ -175,7 +175,7 @@ class FritzMonitor:
     def _get_connected_socket(self, sock=None):
         """
         Takes the given socket and builds a connection to address and port defined
-        at instanciation. If no socket is given a new one gets created.
+        at instantiation. If no socket is given a new one gets created.
         Returns the socket.
         """
         if sock is None:

--- a/fritzconnection/core/logger.py
+++ b/fritzconnection/core/logger.py
@@ -53,7 +53,7 @@ def activate_local_debug_mode(handler=None, propagate=False):
     set, avoiding a call of the lastResort-handler.
     If the given handler has no formatter, the fritzformatter gets set
     (which provides the `logging.BASIC_FORMAT`).
-    If propagate is True, all debug informations will also get send to
+    If propagate is True, all debug information will also get send to
     the parent-handlers. Keep in mind, that this can be a lot of data if
     the parent-handlers are enabled for debug-level records.
     """

--- a/fritzconnection/core/logger.py
+++ b/fritzconnection/core/logger.py
@@ -53,7 +53,7 @@ def activate_local_debug_mode(handler=None, propagate=False):
     set, avoiding a call of the lastResort-handler.
     If the given handler has no formatter, the fritzformatter gets set
     (which provides the `logging.BASIC_FORMAT`).
-    If propagate is True, all debug information will also get send to
+    If propagate is True, all debug information will also get sent to
     the parent-handlers. Keep in mind, that this can be a lot of data if
     the parent-handlers are enabled for debug-level records.
     """

--- a/fritzconnection/core/processor.py
+++ b/fritzconnection/core/processor.py
@@ -255,13 +255,13 @@ class Scpd:
     """
     Provides information about the Service Control Point Definitions
     for every Service. Every Service has one instance of this class for
-    accessing the description of it's own actions and the according
+    accessing the description of its own actions and the according
     parameters.
     Root class for processing the content of an scpd-file.
     """
     def __init__(self, root):
         """
-        Starts interpreting the scpd-data. 'root' must be an xml.Element
+        Starts interpreting the scpd-data. 'root' must be a xml.Element
         objects as returned from 'utils.get_xml_root'.
         """
         self._actions = list()
@@ -283,7 +283,7 @@ class Scpd:
     def actions(self):
         """
         Returns a dictionary with the actions from the actions-list. The
-        action-names are the keys and the actions themself are the
+        action-names are the keys and the actions themselves are the
         values.
         """
         return {action.name: action for action in self._actions}
@@ -361,10 +361,10 @@ class ServiceList(Storage):
 @processor
 class Device:
     """
-    Storage for devices attributes and device subnodes.
-    Subnodes are the serviceList and the deviceList.
+    Storage for devices attributes and device sub-nodes.
+    Sub-nodes are the serviceList and the deviceList.
     The services provided by a device are collected in services.
-    Subdevices are collected in devices.
+    Sub-devices are collected in devices.
     All instance attributes are public for read only use.
     """
     def __init__(self):
@@ -411,7 +411,7 @@ class Description:
     """
     def __init__(self, root):
         """
-        Starts data-processing. 'root' must be an xml.Element object as
+        Starts data-processing. 'root' must be a xml.Element object as
         returned from 'utils.get_xml_root'.
         """
         # attributes are case sensitive node names:
@@ -443,7 +443,7 @@ class Description:
     def system_info(self):
         """
         Returns the systemVersion attributes as a tuple:
-        (HW, Major, Minor, Patch, Bildnumber, Display). This information
+        (HW, Major, Minor, Patch, Buildnumber, Display). This information
         is only available by the 'tr64desc.xml' file.
         """
         return self.systemVersion.info

--- a/fritzconnection/core/processor.py
+++ b/fritzconnection/core/processor.py
@@ -104,7 +104,7 @@ class Storage:
 class SpecVersion:
     """
     Specification version from the schema device or service
-    informations.
+    information.
     """
     def __init__(self):
         # attributes are case sensitive node names:
@@ -253,7 +253,7 @@ class ServiceStateTable(Storage):
 
 class Scpd:
     """
-    Provides informations about the Service Control Point Definitions
+    Provides information about the Service Control Point Definitions
     for every Service. Every Service has one instance of this class for
     accessing the description of it's own actions and the according
     parameters.

--- a/fritzconnection/core/soaper.py
+++ b/fritzconnection/core/soaper.py
@@ -78,7 +78,7 @@ def encode_boolean(value):
     """
     Returns 1 or 0 if the value is True or False.
     None gets interpreted as False.
-    Otherwise the original value is returned.
+    Otherwise, the original value is returned.
     """
     if value is True:
         return 1
@@ -89,12 +89,12 @@ def encode_boolean(value):
 
 def get_html_safe_value(value):
     """
-    Returns an xml `encoded value` if it's an encodable value.
+    Returns a xml `encoded value` if it's an encodable value.
     `value` can be of any type. If it is a boolean or None it
     gets converted to the integer 1 or 0.
     If it is a string the characters in the set `&<>'"` are
     converted to html-safe sequences.
-    Any other datatype get's returned as is.
+    Any other datatype gets returned as is.
     """
     value = encode_boolean(value)
     if isinstance(value, str):
@@ -171,7 +171,7 @@ class Soaper:
 
     For accessing the Fritz!Box the parameters `address` for the router
     ip, `port`, `user`, `password` and `session` are required. (These
-    parameters will get set by FritzConnection,)
+    parameters will get set by FritzConnection.)
     """
 
     headers = {"soapaction": "", "content-type": "text/xml", "charset": "utf-8"}

--- a/fritzconnection/core/utils.py
+++ b/fritzconnection/core/utils.py
@@ -23,7 +23,7 @@ def localname(node):
 def get_content_from(url, timeout=None, session=None):
     """
     Returns text from a get-request for the given url. In case of a
-    secure request (using TLS) the parameter verify is set to False, to
+    secure request (using TLS) the parameter verify is set to False, in order to
     disable certificate verifications. As the Fritz!Box creates a
     self-signed certificate for use in the LAN, encryption will work but
     verification will fail.
@@ -63,14 +63,14 @@ def get_xml_root(source, timeout=None, session=None):
     """
     Function to help migrate from lxml to the standard-library xml-package.
 
-    'source' must be a string and can be an xml-string, a uri or a file
+    'source' must be a string and can be a xml-string, a uri or a file
     name. `timeout` is an optional parameter limiting the time waiting
     for a router response.
-    In all cases this function returns an xml.etree.Element instance
+    In all cases this function returns a xml.etree.Element instance
     which is the root of the parsed tree.
     """
     if source.startswith("http://") or source.startswith("https://"):
-        # it's a uri, use requests to get the content
+        # it's an uri, use requests to get the content
         source = get_content_from(source, timeout=timeout, session=session)
     elif not source.startswith("<"):
         # assume it's a filename

--- a/fritzconnection/lib/fritzcall.py
+++ b/fritzconnection/lib/fritzcall.py
@@ -75,7 +75,7 @@ class FritzCall(AbstractLibraryBase):
                         num=None, days=None):
         """
         Return a list of Call instances of type calltypes. If calltype
-        is 0 all calls are listet. If *update* is True, all calls are
+        is 0 all calls are listed. If *update* is True, all calls are
         reread from the router. *num* maximum number of entries in call
         list. *days* number of days to look back for calls e.g. 1: calls
         from today and yesterday, 7: calls from the complete last week.
@@ -157,7 +157,7 @@ class Call:
     attributes are *Id*, *Type*, *Called*, *Caller*, *CallerNumber*,
     *CalledNumber*, *Name*, *Device*, *Port*, *Date*, *Duration* and
     *Count*. The spelling represents the original xml-node names.
-    Additionally the following attributes can be accessed by lowercase
+    Additionally, the following attributes can be accessed by lowercase
     names: *id* returning the Id as integer, *type* returning the Type
     as integer, *date* returning the Date as datetime-instance,
     *duration* returning the Duration as timedelta-instance.

--- a/fritzconnection/lib/fritzhomeauto.py
+++ b/fritzconnection/lib/fritzhomeauto.py
@@ -8,6 +8,8 @@ Module to access home-automation devices
 
 
 import itertools
+from warnings import warn
+
 from .fritzbase import AbstractLibraryBase
 
 
@@ -57,16 +59,23 @@ class FritzHomeAutomation(AbstractLibraryBase):
 
     def device_informations(self):
         """
+        DEPRECATED: use 'device_information' instead
+        """
+        warn('This method is deprecated. Use "device_information" instead.', DeprecationWarning)
+        return self.device_information()
+
+    def device_information(self):
+        """
         Returns a list of dictionaries for all known homeauto-devices.
         """
-        infos = list()
+        info = list()
         for n in itertools.count():
             try:
                 info = self.get_device_information_by_index(n)
             except IndexError:
                 break
-            infos.append(info)
-        return infos
+            info.append(info)
+        return info
 
     def set_switch(self, identifier, on=True):
         """

--- a/fritzconnection/lib/fritzhomeauto.py
+++ b/fritzconnection/lib/fritzhomeauto.py
@@ -1,5 +1,5 @@
 """
-Modul to access home-automation devices
+Module to access home-automation devices
 """
 # This module is part of the FritzConnection package.
 # https://github.com/kbr/fritzconnection

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -40,7 +40,7 @@ class FritzHosts(AbstractLibraryBase):
 
     def get_generic_host_entry(self, index):
         """
-        Returns a dictionary with informations about a device internally
+        Returns a dictionary with information about a device internally
         registered by the position *index*. Index-positions are
         zero-based.
         """
@@ -60,14 +60,14 @@ class FritzHosts(AbstractLibraryBase):
 
     def get_specific_host_entry(self, mac_address):
         """
-        Returns a dictionary with informations about a device addressed
+        Returns a dictionary with information about a device addressed
         by the MAC-address.
         """
         return self._action("GetSpecificHostEntry", NewMACAddress=mac_address)
 
     def get_specific_host_entry_by_ip(self, ip):
         """
-        Returns a dictionary with informations about a device addressed
+        Returns a dictionary with information about a device addressed
         by the ip-address. Provides additional information about
         connection speed and system-updates for AVM devices.
         """

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -178,7 +178,7 @@ class FritzHosts(AbstractLibraryBase):
         """
         Triggers the host with the given `mac_address` to run a system
         update. The method returns immediately, but for the device it
-        take some time to do the OS update. All vendor warnings about running a
+        takes some time to do the OS update. All vendor warnings about running a
         system update apply, like not turning power off during a system
         update. So run this command with caution.
         """

--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -1,5 +1,5 @@
 """
-Modul to access and control the known hosts.
+Module to access and control the known hosts.
 """
 # This module is part of the FritzConnection package.
 # https://github.com/kbr/fritzconnection

--- a/fritzconnection/lib/fritzphonebook.py
+++ b/fritzconnection/lib/fritzphonebook.py
@@ -74,7 +74,8 @@ class FritzPhonebook(AbstractLibraryBase):
 
     def get_all_name_numbers(self, id):
         """
-        Returns all entries from the phonebook with the given id as a list of tuples. The first item of every tuple is the contact name and the second item is the list of numbers for this contact.
+        Returns all entries from the phonebook with the given id as a list of tuples. The first item of every tuple is
+        the contact name and the second item is the list of numbers for this contact.
         """
         url = self.phonebook_info(id)['url']
         self._read_phonebook(url)
@@ -86,7 +87,9 @@ class FritzPhonebook(AbstractLibraryBase):
     def get_all_names(self, id):
         """
         Get a dictionary with all names and their phone numbers for the
-        phonebook with `id`. If a name is given more than once in a single phonebook, the last entry will overwrite the previous entries. (That's because the names are the keys in the dictionary returned from this method. In this case use the method 'get_all_name_numbers()' to get all entries as a list of tuples.)
+        phonebook with `id`. If a name is given more than once in a single phonebook, the last entry will overwrite
+        the previous entries. (That's because the names are the keys in the dictionary returned from this method.
+        In this case use the method 'get_all_name_numbers()' to get all entries as a list of tuples.)
         """
         return {name: number for name, number in self.get_all_name_numbers(id)}
 
@@ -162,8 +165,8 @@ class Telephony:
 @processor
 class Contact:
     """
-    Represents a contact with `catecory`- and `uniqueid`-attributes as
-    well as `person`- and telephony-subnodes.
+    Represents a contact with `category`- and `uniqueid`-attributes as
+    well as `person`- and telephony-sub-nodes.
     """
 
     def __init__(self):

--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -1,5 +1,5 @@
 """
-Modul to read status-informations from an AVM FritzBox.
+Module to read status-informations from an AVM FritzBox.
 """
 
 import time

--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -110,7 +110,7 @@ class FritzStatus(AbstractLibraryBase):
 
     @property
     def str_uptime(self):
-        """Connection uptime in human readable format."""
+        """Connection uptime in human-readable format."""
         mins, secs = divmod(self.uptime, 60)
         hours, mins = divmod(mins, 60)
         return "%02d:%02d:%02d" % (hours, mins, secs)
@@ -157,7 +157,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def str_transmission_rate(self):
         """
-        Tuple of human readable transmission rate in bytes. First item
+        Tuple of human-readable transmission rate in bytes. First item
         is upstream, second item downstream.
         """
         upstream, downstream = self.transmission_rate
@@ -166,7 +166,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def max_linked_bit_rate(self):
         """
-        Tuple with the maximun upstream- and downstream-rate
+        Tuple with the maximum upstream- and downstream-rate
         of the physical link. The rate is given in bits/sec.
         """
         return self._get_max_bit_rate("WANCommonInterfaceConfig")
@@ -174,7 +174,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def max_bit_rate(self):
         """
-        Tuple with the maximun upstream- and downstream-rate
+        Tuple with the maximum upstream- and downstream-rate
         of the given connection. The rate is given in bits/sec.
         """
         return self._get_max_bit_rate("WANCommonIFC")
@@ -200,7 +200,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def str_max_linked_bit_rate(self):
         """
-        Human readable maximum of the physical upstream- and
+        Human-readable maximum of the physical upstream- and
         downstream-rate in bits/sec. Value is a tuple, first item is
         upstream, second item is downstream.
         """
@@ -213,7 +213,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def str_max_bit_rate(self):
         """
-        Human readable maximum of the upstream- and downstream-rate in
+        Human-readable maximum of the upstream- and downstream-rate in
         bits/sec, as given by the provider. Value is a tuple, first item
         is upstream, second item is downstream.
         """
@@ -262,7 +262,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def str_noise_margin(self):
         """
-        Human readable noise margin in dB. Value is a tuple, first item
+        Human-readable noise margin in dB. Value is a tuple, first item
         is upstream, second item downstream.
         """
         upstream, downstream = self.noise_margin
@@ -282,7 +282,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def str_attenuation(self):
         """
-        Human readable attenuation in dB. Value is a tuple, first item
+        Human-readable attenuation in dB. Value is a tuple, first item
         is upstream, second item downstream.
         """
         upstream, downstream = self.attenuation

--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -1,5 +1,5 @@
 """
-Module to read status-informations from an AVM FritzBox.
+Module to read status-information from an AVM FritzBox.
 """
 
 import time
@@ -22,7 +22,7 @@ def _integer_or_original(value):
 
 class FritzStatus(AbstractLibraryBase):
     """
-    Class for requesting status-informations: up, down, ip, activity
+    Class for requesting status-information: up, down, ip, activity
     (bytes per second send/received). All parameters are optional. If
     given, they have the following meaning: `fc` is an instance of
     FritzConnection, `address` the ip of the Fritz!Box, `port` the port
@@ -64,7 +64,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def external_ipv6_info(self):
         """
-        Returns the ipv6 external address informations as a dictionary with the keys:
+        Returns the ipv6 external address information as a dictionary with the keys:
         NewExternalIPv6Address                   out ->     string
         NewPrefixLength                          out ->     ui1
         NewValidLifetime                         out ->     ui4
@@ -80,7 +80,7 @@ class FritzStatus(AbstractLibraryBase):
     @property
     def ipv6_prefix_info(self):
         """
-        Returns the ipv6 prefix informations as a dictionary with the keys:
+        Returns the ipv6 prefix information as a dictionary with the keys:
         NewIPv6Prefix                            out ->     string
         NewPrefixLength                          out ->     ui1
         NewValidLifetime                         out ->     ui4

--- a/fritzconnection/lib/fritztools.py
+++ b/fritzconnection/lib/fritztools.py
@@ -30,7 +30,7 @@ def byte_formatter(value):
 
 def format_num(num, unit='bytes'):
     """
-    Returns a human readable string of a byte-value.
+    Returns a human-readable string of a byte-value.
     If 'num' is bits, set unit='bits'.
     """
     num, dim = byte_formatter(num)
@@ -41,7 +41,7 @@ def format_num(num, unit='bytes'):
 
 def format_rate(num, unit='bytes'):
     """
-    Returns a human readable string of a byte/bits per second.
+    Returns a human-readable string of a byte/bits per second.
     If 'num' is bits, set unit='bits'.
     """
     return format_num(num, unit=unit) + '/s'
@@ -49,7 +49,7 @@ def format_rate(num, unit='bytes'):
 
 def format_dB(num):
     """
-    Returns a human readable string of dB. The value is divided
+    Returns a human-readable string of dB. The value is divided
     by 10 to get first decimal digit
     """
     num /= 10

--- a/fritzconnection/lib/fritzwlan.py
+++ b/fritzconnection/lib/fritzwlan.py
@@ -1,5 +1,5 @@
 """
-Module to get informations about WLAN devices.
+Module to get information about WLAN devices.
 """
 # This module is part of the FritzConnection package.
 # https://github.com/kbr/fritzconnection
@@ -9,6 +9,8 @@ Module to get informations about WLAN devices.
 import itertools
 import random
 import string
+
+from warnings import warn
 
 from ..core.exceptions import FritzServiceError
 from .fritzbase import AbstractLibraryBase
@@ -78,14 +80,21 @@ class FritzWLAN(AbstractLibraryBase):
     @property
     def channel(self):
         """The WLAN channel in use"""
-        return self.channel_infos()['NewChannel']
+        return self.channel_info()['NewChannel']
 
     @property
     def alternative_channels(self):
         """Alternative channels (as string)"""
-        return self.channel_infos()['NewPossibleChannels']
+        return self.channel_info()['NewPossibleChannels']
 
     def channel_infos(self):
+        """
+        DEPRECATED: use 'channel_info' instead
+        """
+        warn('This method is deprecated. Use "channel_info" instead.', DeprecationWarning)
+        return self.channel_info()
+
+    def channel_info(self):
         """
         Return a dictionary with the keys *NewChannel* and
         *NewPossibleChannels* indicating the active channel and
@@ -102,7 +111,7 @@ class FritzWLAN(AbstractLibraryBase):
 
     def get_generic_host_entry(self, index):
         """
-        Return a dictionary with informations about the device
+        Return a dictionary with information about the device
         internally stored at the position 'index'.
         """
         result = self._action(
@@ -113,7 +122,7 @@ class FritzWLAN(AbstractLibraryBase):
 
     def get_specific_host_entry(self, mac_address):
         """
-        Return a dictionary with informations about the device
+        Return a dictionary with information about the device
         with the given 'mac_address'.
         """
         result = self._action(
@@ -128,13 +137,13 @@ class FritzWLAN(AbstractLibraryBase):
         hosts. The dict-keys are: 'service', 'index', 'status', 'mac',
         'ip', 'signal', 'speed'
         """
-        informations = []
+        information = []
         for index in itertools.count():
             try:
                 host = self.get_generic_host_entry(index)
             except IndexError:
                 break
-            informations.append({
+            information.append({
                 'service': self.service,
                 'index': index,
                 'status': host['NewAssociatedDeviceAuthState'],
@@ -143,11 +152,11 @@ class FritzWLAN(AbstractLibraryBase):
                 'signal': host['NewX_AVM-DE_SignalStrength'],
                 'speed': host['NewX_AVM-DE_Speed']
             })
-        return informations
+        return information
 
     def get_info(self):
         """
-        Returns a dictionary with general internal informations about
+        Returns a dictionary with general internal information about
         the current wlan network according to the AVM documentation.
         """
         return self._action("GetInfo")

--- a/fritzconnection/lib/fritzwlan.py
+++ b/fritzconnection/lib/fritzwlan.py
@@ -53,7 +53,7 @@ class FritzWLAN(AbstractLibraryBase):
     @property
     def total_host_number(self):
         """
-        Total NewAssociatedDeviceIndexumber of registered wlan devices
+        Total NewAssociatedDeviceIndexNumber of registered wlan devices
         for all WLANConfigurations.
         """
         total = 0
@@ -187,7 +187,7 @@ class FritzWLAN(AbstractLibraryBase):
         Sets a new password for the associated wlan.
         If no password is given a new one is created with the given
         length (the new password can get read with a subsequent call of
-        `get_password`). Also creates a new preshared key.
+        `get_password`). Also creates a new pre-shared key.
         """
         preshared_key = self._create_preshared_key()
         password = password or self._create_password(length)
@@ -203,7 +203,7 @@ class FritzWLAN(AbstractLibraryBase):
 
     def _create_preshared_key(self):
         """
-        Returns a new preshared key for setting a new password.
+        Returns a new pre-shared key for setting a new password.
         The sequence is of uppercase characters as this is default on FritzOS
         at time of writing.
         """
@@ -215,9 +215,9 @@ class FritzWLAN(AbstractLibraryBase):
     @staticmethod
     def _create_password(length):
         """
-        Returns a human readable password with the given length.
+        Returns a human-readable password with the given length.
         """
-        # add just two human readable special characters.
+        # add just two human-readable special characters.
         # password strength increases with the length.
         # character permutations are: 64**length
         characters = string.ascii_letters + string.digits + "@#"
@@ -241,7 +241,7 @@ class FritzGuestWLAN(FritzWLAN):
     """
     def __init__(self, *args, **kwargs):
         """
-        Initialize a the guest wlan instance. All parameters are
+        Initialize the guest wlan instance. All parameters are
         optional. If given, they have the following meaning: `fc` is an
         instance of FritzConnection, `address` the ip of the Fritz!Box,
         `port` the port to connect to, `user` the username, `password`


### PR DESCRIPTION
Hey there,

I fixed some typos and made a few other improvements regarding wording or english grammar in general.
The most "severe" one should be the refactoring of all usages of `informations`; which occured in both comments/documentation and function-/variable-names.

`Information` is a mass noun. It has no plural form.
Normally this wouldn't be a big deal. But since this is a general library, imho it should use proper grammar.

Would be nice if you could review my changes and merge the PR.

Again... thanks a lot!