### PR TITLE
Bugfix: "name 'fc' is not defined" in FritzStatus.get_device_info()

### DIFF
--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -334,7 +334,7 @@ class FritzStatus(AbstractLibraryBase):
         .. versionadded:: 1.10
 
         """
-        return ArgumentNamespace(fc.call_action("DeviceInfo1", "GetInfo"))
+        return ArgumentNamespace(self.fc.call_action("DeviceInfo1", "GetInfo"))
 
     def get_default_connection_service(self):
         """


### PR DESCRIPTION
Just a small bugfix where a 'self' appears to have been forgotten.