### PR TITLE
Add FritzAuthorizationError

### DIFF
--- a/fritzconnection/core/exceptions.py
+++ b/fritzconnection/core/exceptions.py
@@ -170,6 +170,11 @@ class FritzArrayIndexError(FritzConnectionException, IndexError):
     So IndexError can also be used for exception handling.
     """
 
+class FritzAuthorizationError(FritzConnectionException):
+    """
+    Authentication error. 
+    Not allowed to access the box at all.
+    """
 
 # Collection of error codes and corresponding exceptions:
 # (the error codes are defined by AVM)

--- a/fritzconnection/core/soaper.py
+++ b/fritzconnection/core/soaper.py
@@ -18,6 +18,7 @@ from xml.etree import ElementTree as etree
 from .exceptions import (
     FritzConnectionException,
     FRITZ_ERRORS,
+    FritzSecurityError,
 )
 from .logger import fritzlogger
 from .utils import localname
@@ -136,6 +137,11 @@ def raise_fritzconnection_error(response):
     """
     parts = []
     error_code = None
+
+    # raise on authorization error
+    if response.status_code == 401:
+        raise FritzSecurityError(response.text)
+
     try:
         root = etree.fromstring(response.content)
     except etree.ParseError:

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -79,7 +79,6 @@ def test_raise_fritzconnection_error(error_code, exception):
     """check for exception raising depending on the error_code"""
     content = content_template.format(error_code=error_code)
     response = Response()
-    response.status_code = 500
     response.content = content.encode()
     pytest.raises(exception, raise_fritzconnection_error, response)
 
@@ -137,7 +136,6 @@ UPnPError </faultstring>
 
 def test_long_error_message():
     response = Response()
-    response.status_code = 500
     response.content = long_error.encode()
     with pytest.raises(ActionError) as exc:
         raise_fritzconnection_error(response)

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -4,11 +4,9 @@ from xml.etree import ElementTree as etree
 import pytest
 
 from ..core.exceptions import (
-    FRITZ_ERRORS,
     ActionError,
     FritzAuthorizationError,
     FritzConnectionException,
-    ServiceError,
     FritzActionError,
     FritzArgumentError,
     FritzActionFailedError,

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -83,7 +83,7 @@ def test_raise_fritzconnection_error(error_code, exception):
     pytest.raises(exception, raise_fritzconnection_error, response)
 
 def test_raise_fritzauthorization_error():
-    """check for exception raising depending on the error_code"""
+    """check for exception raising depending on the html status code."""
     response = Response()
     response.content = b'<HTML><HEAD><TITLE>401 Unauthorized (ERR_NONE)</TITLE></HEAD><BODY><H1>401 Unauthorized</H1><BR>ERR_NONE<HR><B>Webserver</B> Sat, 01 Oct 2022 09:46:22 GMT</BODY></HTML>'
     response.text = '<HTML><HEAD><TITLE>401 Unauthorized (ERR_NONE)</TITLE></HEAD><BODY><H1>401 Unauthorized</H1><BR>ERR_NONE<HR><B>Webserver</B> Sat, 01 Oct 2022 09:46:22 GMT</BODY></HTML>'

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -79,9 +79,17 @@ def test_raise_fritzconnection_error(error_code, exception):
     """check for exception raising depending on the error_code"""
     content = content_template.format(error_code=error_code)
     response = Response()
+    response.status_code = 500
     response.content = content.encode()
     pytest.raises(exception, raise_fritzconnection_error, response)
 
+def test_raise_fritzsecurity_error():
+    """check for exception raising depending on the error_code"""
+    response = Response()
+    response.content = "<HTML><HEAD><TITLE>401 Unauthorized (ERR_NONE)</TITLE></HEAD></HTML>".encode()
+    response.text = "<HTML><HEAD><TITLE>401 Unauthorized (ERR_NONE)</TITLE></HEAD></HTML>"
+    response.status_code = 401
+    pytest.raises(FritzSecurityError, raise_fritzconnection_error, response)
 
 @pytest.mark.parametrize(
     "value, expected_result", [
@@ -123,6 +131,7 @@ UPnPError </faultstring>
 
 def test_long_error_message():
     response = Response()
+    response.status_code = 500
     response.content = long_error.encode()
     with pytest.raises(ActionError) as exc:
         raise_fritzconnection_error(response)


### PR DESCRIPTION
Actually, it is not differentiated between possible reasons for a connection issue (_eq. unreachable or un-authorized_).
This causes issues in handling connection issues (_see [home-assistant/core/issues/71822](https://github.com/home-assistant/core/issues/71822#issuecomment-1139686592)_)

With this a http-401 will raise a `FritzSecurityError`, which ensures that the we can distinguish between wrong credentials or just not reachable device.

cc @chemelli74 

---

### prior this change

```
./test.py 
FRITZ!Box 7530 AX at http://192.168.1.1
FRITZ!OS: 7.31
Traceback (most recent call last):
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 146, in raise_fritzconnection_error
    root = etree.fromstring(response.content)
  File "/usr/lib/python3.10/xml/etree/ElementTree.py", line 1349, in XML
    parser.feed(text)
xml.etree.ElementTree.ParseError: mismatched tag: line 1, column 156

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mib85/git/fritzconnection/./test.py", line 14, in <module>
    main()
  File "/home/mib85/git/fritzconnection/./test.py", line 10, in main
    info = fritz_status.get_device_info()
  File "/home/mib85/git/fritzconnection/fritzconnection/lib/fritzstatus.py", line 337, in get_device_info
    return ArgumentNamespace(self.fc.call_action("DeviceInfo1", "GetInfo"))
  File "/home/mib85/git/fritzconnection/fritzconnection/core/fritzconnection.py", line 397, in call_action
    return self.soaper.execute(service, action_name, arguments)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 265, in execute
    return handle_response(response)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 247, in handle_response
    raise_fritzconnection_error(response)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 156, in raise_fritzconnection_error
    raise FritzConnectionException(msg)
fritzconnection.core.exceptions.FritzConnectionException: Unable to perform operation. 401 Unauthorized (ERR_NONE)401 UnauthorizedERR_NONEWebserver Sun, 25 Sep 2022 14:58:07 GMT
```


### with this change

```
./test.py 
FRITZ!Box 7530 AX at http://192.168.1.1
FRITZ!OS: 7.31
Traceback (most recent call last):
  File "/home/mib85/git/fritzconnection/./test.py", line 14, in <module>
    main()
  File "/home/mib85/git/fritzconnection/./test.py", line 10, in main
    info = fritz_status.get_device_info()
  File "/home/mib85/git/fritzconnection/fritzconnection/lib/fritzstatus.py", line 337, in get_device_info
    return ArgumentNamespace(self.fc.call_action("DeviceInfo1", "GetInfo"))
  File "/home/mib85/git/fritzconnection/fritzconnection/core/fritzconnection.py", line 397, in call_action
    return self.soaper.execute(service, action_name, arguments)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 265, in execute
    return handle_response(response)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 247, in handle_response
    raise_fritzconnection_error(response)
  File "/home/mib85/git/fritzconnection/fritzconnection/core/soaper.py", line 143, in raise_fritzconnection_error
    raise FritzSecurityError(response.text)
fritzconnection.core.exceptions.FritzSecurityError: <HTML><HEAD><TITLE>401 Unauthorized (ERR_NONE)</TITLE></HEAD><BODY><H1>401 Unauthorized</H1><BR>ERR_NONE<HR><B>Webserver</B> Sun, 25 Sep 2022 14:57:28 GMT</BODY></HTML>
```
