### PR TITLE
Ensure directory exits when writing cache

### DIFF
--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -595,6 +595,9 @@ class FritzConnection:
         binary = "wb"
         text = "wt"
         mode = binary if cache_format == FRITZ_CACHE_FORMAT_PICKLE else text
+        cache_directory = os.path.dirname(path)
+        if not os.path.isdir(cache_directory):
+            os.makedirs(cache_directory)
         with open(path, mode) as fobj:
             if mode == binary:
                 pickle.dump(self.device_manager.descriptions, fobj)


### PR DESCRIPTION
Making a FritzConnection() with use_cache=True fails on a new installation because of non existing cache-directory:
```

>>> from fritzconnection import FritzConnection
>>> fc = FritzConnection(address="192.168.178.1", use_cache=True)
Traceback (most recent call last):
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 454, in _load_router_api
    self._load_api_from_cache(path, cache_format)
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 533, in _load_api_from_cache
    with open(path, mode) as fobj:
FileNotFoundError: [Errno 2] No such file or directory: '/home/stw/.fritzconnection/192_168_178_1_cache.pcl'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 246, in __init__
    self._load_router_api(
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 457, in _load_router_api
    reload_api()
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 449, in reload_api
    self._write_api_to_cache(path, cache_format)
  File "/home/stw/.local/lib/python3.10/site-packages/fritzconnection/core/fritzconnection.py", line 515, in _write_api_to_cache
    with open(path, mode) as fobj:
FileNotFoundError: [Errno 2] No such file or directory: '/home/stw/.fritzconnection/192_168_178_1_cache.pcl'


```