### PR TITLE
Adding hangup to cancel a dialing process

### DIFF
--- a/fritzconnection/lib/fritzcall.py
+++ b/fritzconnection/lib/fritzcall.py
@@ -128,6 +128,12 @@ class FritzCall(AbstractLibraryBase):
         """
         arg = {'NewX_AVM-DE_PhoneNumber': number}
         self.fc.call_action('X_VoIP1', 'X_AVM-DE_DialNumber', arguments=arg)
+        
+    def hangup(self):
+        """
+        Terminates the dialling process initiated by the dial function.
+        """
+        self.fc.call_action('X_VoIP1', 'X_AVM-DE_DialHangup')
 
 
 class AttributeConverter:


### PR DESCRIPTION
Since we have a way to start a dialing process in the library we should also be able to cancel that process. For example useful when using dial for a notification / doorbell sound.