### PR TITLE
Fix FritzHost.get_hosts_attributes()

### DIFF
--- a/fritzconnection/lib/fritzhosts.py
+++ b/fritzconnection/lib/fritzhosts.py
@@ -204,6 +204,7 @@ class FritzHosts(AbstractLibraryBase):
         .. versionadded:: 1.10
         """
         result = self._action("X_AVM-DE_GetHostListPath")
-        url = result["NewX_AVM-DE_HostListPath"]
-        storage = HostStorage(get_xml_root(url, self.fc.session))
+        path = result["NewX_AVM-DE_HostListPath"]
+        url = f"{self.fc.address}:{self.fc.port}{path}"
+        storage = HostStorage(get_xml_root(source=url, session=self.fc.session))
         return storage.hosts_attributes


### PR DESCRIPTION
Hi @kbr

this will fix two issues with the `get_hosts_attributes`

### 1. url incomplete

https://github.com/kbr/fritzconnection/blob/790b5872b3cabb2a65dca9175a9e22819215183f/fritzconnection/lib/fritzhosts.py#L206-L207

`NewX_AVM-DE_HostListPath` does only contain the path, but not the full url

### 2. arguments given to `get_xml_root`

https://github.com/kbr/fritzconnection/blob/790b5872b3cabb2a65dca9175a9e22819215183f/fritzconnection/lib/fritzhosts.py#L208

[`def get_xml_root(source, timeout=None, session=None)`](https://github.com/kbr/fritzconnection/blob/790b5872b3cabb2a65dca9175a9e22819215183f/fritzconnection/core/utils.py#L66) takes one positional and two optional arguments

---

I guess this is caused by the "different implementation" stated in https://github.com/kbr/fritzconnection/issues/134#issuecomment-1200162131 🤔 