### PR TITLE
removed required password from fritzstatus

### DIFF
--- a/fritzconnection/cli/fritzstatus.py
+++ b/fritzconnection/cli/fritzstatus.py
@@ -39,12 +39,9 @@ def print_status(fs):
 
 def main():
     args = get_cli_arguments()
-    if not args.password:
-        print("Exit: password required.")
-    else:
-        fs = get_instance(FritzStatus, args)
-        print_header(fs)
-        print_status(fs)
+    fs = get_instance(FritzStatus, args)
+    print_header(fs)
+    print_status(fs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The password for `fritzstatus` is not needed, because the services called on FritzOS don't need an authentification for `fritzstatus`.

See https://github.com/kbr/fritzconnection/issues/102#issuecomment-874198719

This will avoid any confusion for the required password (which isn't used anyway by fritzstatus.py).