### PR TITLE
New QR codes text kinds

### DIFF
--- a/fritzconnection/lib/fritzwlan.py
+++ b/fritzconnection/lib/fritzwlan.py
@@ -68,7 +68,7 @@ def _get_beacon_security(instance, security):
 
 def _get_wifi_qr_code(instance, kind='svg',
                      security=None, hidden=False,
-                     scale=4):
+                     scale=4, border=0):
     """
     Returns a file-like object providing a bytestring representing a
     qr-code for wlan access. `instance` is a FritzWLAN or FritzGuestWLAN
@@ -130,10 +130,10 @@ def _get_wifi_qr_code(instance, kind='svg',
     if kind in ['text', 'text-compact']:
         stream = io.StringIO()
         compact = kind != 'text'
-        qr_code.terminal(out=stream, border=0, compact=compact)
+        qr_code.terminal(out=stream, border=border, compact=compact)
     else:
         stream = io.BytesIO()
-        qr_code.save(out=stream, kind=kind, scale=scale)
+        qr_code.save(out=stream, kind=kind, scale=scale, border=border)
     stream.seek(0)
     return stream
 

--- a/fritzconnection/lib/fritzwlan.py
+++ b/fritzconnection/lib/fritzwlan.py
@@ -73,7 +73,7 @@ def _get_wifi_qr_code(instance, kind='svg',
     Returns a file-like object providing a bytestring representing a
     qr-code for wlan access. `instance` is a FritzWLAN or FritzGuestWLAN
     instance. `kind` describes the type of the qr-code. Supported types
-    are: 'svg', 'png' and 'pdf'. Default is 'svg'.
+    are: 'svg', 'png', 'pdf', 'text' and 'text-compact'. Default is 'svg'.
 
     This function is not intended to get called directly. Instead it is
     available as a method on FritzWLAN instances (as well as on
@@ -92,6 +92,11 @@ def _get_wifi_qr_code(instance, kind='svg',
 
         with open('qr_code.png', 'wb') as fobj:
             fobj.write(stream.read())
+
+    The stream can be printed out if qr-code is represented as text: ::
+
+        stream = guest_wlan.get_wifi_qr_code(kind='text')
+        print(stream.getvalue())
 
     If `segno` is not installed the call will trigger an
     AttributeError when called on an instance and a NameError when
@@ -115,7 +120,6 @@ def _get_wifi_qr_code(instance, kind='svg',
     .. versionadded:: 1.10
 
     """
-    stream = io.BytesIO()
     security = _get_beacon_security(instance, security)
     qr_code = segno.helpers.make_wifi(
         ssid=instance.ssid,
@@ -123,7 +127,13 @@ def _get_wifi_qr_code(instance, kind='svg',
         security=security,
         hidden=hidden
     )
-    qr_code.save(out=stream, kind=kind, scale=scale)
+    if kind in ['text', 'text-compact']:
+        stream = io.StringIO()
+        compact = kind != 'text'
+        qr_code.terminal(out=stream, border=0, compact=compact)
+    else:
+        stream = io.BytesIO()
+        qr_code.save(out=stream, kind=kind, scale=scale)
     stream.seek(0)
     return stream
 


### PR DESCRIPTION
As I mentioned in #222, it is sometimes necessary to have the QR code as text. The segno library offers the possibility to output QR code as string stream with ANSI or unicode. So I added two new QR code kinds `text` and `text-compact`.