### PR TITLE
Add cpu_temp property to fritz status

### DIFF
--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -486,9 +486,7 @@ class FritzConnection:
 
         .. versionadded:: 1.12
         """
-        header, content = self.http_interface.execute(
-            command,
-            identifier,
+        header, content = self.http_interface.executeQuery(
             **kwargs
         )
         content_type, charset = [item.strip() for item in header.split(";")]
@@ -499,6 +497,16 @@ class FritzConnection:
             "encoding": encoding,
             "content": content
         }
+    
+    def call_http_query(
+        self,
+        payload
+    ) -> dict[str, str]:
+        """
+        Send a request to the query.lua endpoint.
+        """
+        content = self.http_interface.executeQuery(payload)
+        return content
 
     def reconnect(self) -> None:
         """

--- a/fritzconnection/lib/fritzstatus.py
+++ b/fritzconnection/lib/fritzstatus.py
@@ -392,3 +392,10 @@ class FritzStatus(AbstractLibraryBase):
         False otherwise.
         """
         return "Layer3Forwarding1" in self.fc.services
+    
+    @property
+    def cpu_temp(self) -> int:
+        """
+        Returns the current cpu temperature.
+        """
+        return self.fc.call_http_query({ "CPUTEMP": "cpu:status/StatTemperature" })["CPUTEMP"].split(",")[0]


### PR DESCRIPTION
I added the cpu_temp property that returns an integer with the current CPU temperature and the call_http_query() method that lets you do custom requests to the query.lua endpoint.