### PR TITLE
Fix SyntaxWarning in soaper.py due to using '\d' in string

### DIFF
--- a/fritzconnection/core/soaper.py
+++ b/fritzconnection/core/soaper.py
@@ -204,7 +204,7 @@ def redact_response(redact: bool, input: str):
     redacted = re.sub(r"(<{0}>)(.*)(</{0}>)".format(ext_ip_keys), r"\1******\4", redacted)
 
     # redact wifi passwords
-    wifi_pwd_keys = 'New(WEPKey\d+|PreSharedKey|KeyPassphrase)'
+    wifi_pwd_keys = r'New(WEPKey\d+|PreSharedKey|KeyPassphrase)'
     redacted = re.sub(r"(<{0}>)(.*)(</{0}>)".format(wifi_pwd_keys), r"\1******\4", redacted)
     return redacted
 


### PR DESCRIPTION
Right now, the following SyntaxWarning is printed:
```
/.../fritzconnection/core/soaper.py:207: SyntaxWarning: invalid escape sequence '\d'
  wifi_pwd_keys = 'New(WEPKey\d+|PreSharedKey|KeyPassphrase)'
```

This is caused as `\` needs to be escaped in non-raw strings. To fix that, the string should be prefixed with `r` to mark it as a raw string (which could then include any escape sequences, not just something like `\n`).