### PR TITLE
Fix syntax error in redaction regex

### DIFF
--- a/fritzconnection/core/soaper.py
+++ b/fritzconnection/core/soaper.py
@@ -204,7 +204,7 @@ def redact_response(redact: bool, input: str):
     redacted = re.sub(r"(<{0}>)(.*)(</{0}>)".format(ext_ip_keys), r"\1******\4", redacted)
 
     # redact wifi passwords
-    wifi_pwd_keys = 'New(WEPKey\d+|PreSharedKey|KeyPassphrase)'
+    wifi_pwd_keys = 'New(WEPKey\\d+|PreSharedKey|KeyPassphrase)'
     redacted = re.sub(r"(<{0}>)(.*)(</{0}>)".format(wifi_pwd_keys), r"\1******\4", redacted)
     return redacted
 


### PR DESCRIPTION
\d is an non existing escape code, like \n.

I saw an warning in my homeassistant logs
```
homeassistant  | 2025-10-15 17:52:04.948 WARNING (ImportExecutor_0) [py.warnings] /usr/local/lib/python3.13/site-packages/fritzconnection/core/soaper.py:207: SyntaxWarning: invalid escape sequence '\d'
homeassistant  |   wifi_pwd_keys = 'New(WEPKey\d+|PreSharedKey|KeyPassphrase)'
```
and wanted to fix it