### PR TITLE
support for multi factor tokens on action invocations

### DIFF
--- a/docs/sources/getting_started.rst
+++ b/docs/sources/getting_started.rst
@@ -286,12 +286,14 @@ Here just one argument is listed for the in-direction. That means that this argu
 
 This call will deactivate the network (beware: don't deactivate a wireless network by not having a backup cable connection). As there are no arguments listed for the out-direction, `call_action` will return an empty dictionary.
 
+In some cases an action may require that a multi-factor token be provided. You can find you more about this in the official `documentation https://fritz.support/resources/TR-064_Authentication.pdf`_. To supply a multi-factor token for an action, use the keyword argument `multi_factor_token`.
+
 In some cases it can happen that there is a dash in an argument-name. Then this argument-name is not usable as a keyword-parameter. Therefore the `call_action` method also accepts a keyword-only argument with the name `arguments` that must be a dictionary with all input-parameters as key-value pairs (*new in 1.0*): ::
 
     arguments = {'NewEnable': False}
     fc.call_action('WLANConfiguration1', 'SetEnable', arguments=arguments)
 
-If `arguments` is given, the values of all further keyword-parameters are ignored; you can use just one way to provide arguments.
+If `arguments` or `multi_factor_token` are supplied, the values of all further keyword-parameters are ignored; you can use just one way to provide arguments.
 
 .. note ::
     Prior to version 1.3 booleans must be given as numeric values 1 and 0. Since version 1.3 `True` and `False` can get used.

--- a/fritzconnection/core/fritzconnection.py
+++ b/fritzconnection/core/fritzconnection.py
@@ -429,15 +429,23 @@ class FritzConnection:
         service_name: str,
         action_name: str,
         *,
+        multi_factor_token: str | None = None,
         arguments: dict | None = None,
         **kwargs
     ) -> dict[str, Any]:
         """
         Executes the given action of the given service. Both parameters
-        are required. Arguments are optional and can be provided as a
-        dictionary given to 'arguments' or as separate keyword
-        parameters. If 'arguments' is given additional
-        keyword-parameters as further arguments are ignored.
+        are required.
+
+        The argument 'multi_factor_token' is a multi-factor authentication
+        token required for some API calls and is an optional argument.
+        See [here](https://fritz.support/resources/TR-064_Authentication.pdf)
+        for details about this.
+
+        Arguments are optional and can be provided as a dictionary given
+        to 'arguments' or as separate keyword parameters. If 'arguments'
+        or 'multi_factor_token' are given, additional keyword-parameters as
+        further arguments are ignored.
 
         The argument values can be of type *str*, *int* or *bool*.
         (Note: *bool* is provided since 1.3. In former versions booleans
@@ -456,14 +464,14 @@ class FritzConnection:
         values are converted from strings to Python datatypes.
         """
         arguments = arguments if arguments else dict()
-        if not arguments:
+        if not arguments and not multi_factor_token:
             arguments.update(kwargs)
         service_name = self.normalize_name(service_name)
         try:
             service = self.device_manager.services[service_name]
         except KeyError:
             raise FritzServiceError(f'unknown service: "{service_name}"')
-        return self.soaper.execute(service, action_name, arguments)
+        return self.soaper.execute(service, action_name, arguments, multi_factor_token = multi_factor_token)
 
     def call_http(
         self,

--- a/fritzconnection/core/soaper.py
+++ b/fritzconnection/core/soaper.py
@@ -226,7 +226,7 @@ class Soaper:
         """
         <?xml version="1.0" encoding="utf-8"?>
         <s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
-                    xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">{body}
+                    xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">{header}{body}
         </s:Envelope>
         """,
     ).replace('/"xmlns:', '/" xmlns:')
@@ -240,6 +240,16 @@ class Soaper:
         </u:{action_name}>
         </s:Body>
         """,
+    )
+
+    header_template = re.sub(
+        r"\s +",
+        "",
+        """
+        <s:Header>
+        {headers}
+        </s:Header>
+        """
     )
 
     argument_template = "<{name}>{value}</{name}>"
@@ -272,11 +282,37 @@ class Soaper:
             arguments=arguments,
         )
 
-    def execute(self, service, action_name, arguments):
+    def get_header(self, multi_factor_token):
+        """Returns the header by template substitution.
+
+        If the supplied arguments mean that here are no header entries required then
+        this function will return the empty string.
+        """
+
+        headers = []
+
+        if multi_factor_token:
+            headers.append("<avm:token xmlns:avm=\"avm.de\" s:mustUnderstand=\"1\">{token}</avm:token>".format(
+                token = get_html_safe_value(multi_factor_token),
+            ))
+
+        if headers:
+            return self.header_template.format(headers="".join(headers))
+
+        return ""
+
+    def execute(self, service, action_name, arguments, *, multi_factor_token):
         """
         Builds the soap request and returns the response as dictionary.
         Numeric and boolean values are converted from strings to Python
         datatypes.
+
+        The argument 'multi_factor_token' is a multi-factor authentication
+        token required for some API calls and is an optional argument.
+        See [here](https://fritz.support/resources/TR-064_Authentication.pdf)
+        for details about this. If supplied, additional SOAP header data will
+        form part of the SOAP envelope sent to the router. The expected type
+        of this field is `str` or `None`.
         """
 
         def handle_response(response):
@@ -293,7 +329,8 @@ class Soaper:
             self.argument_template.format(name=k, value=v) for k, v in arguments.items()
         )
         body = self.get_body(service, action_name, arguments)
-        envelope = self.envelope.format(body=body).encode("utf-8")
+        header = self.get_header(multi_factor_token)
+        envelope = self.envelope.format(body=body, header=header).encode("utf-8")
         url = f"{self.address}:{self.port}{service.controlURL}"
         fritzlogger.debug(f"\n{url}")
         fritzlogger.debug(envelope)

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -32,6 +32,7 @@ from ..core.soaper import (
     raise_fritzconnection_error,
     redact_response,
     remove_html_tags,
+    Soaper,
 )
 
 
@@ -430,3 +431,16 @@ def test_redact_debug_log_wifi_passwords():
     </s:Body>
     </s:Envelope>
     """
+
+def test_header_empty():
+    """This case covers the situation where there is nothing to add into the header block."""
+    soaper = Soaper("1.1.1.1", 12345, "xxxunam", "xxxpwd")
+    actual_header = soaper.get_header(multi_factor_token = None)
+    assert actual_header == ""
+
+def test_header_token():
+    """This case covers the situation where there is nothing to add into the header block."""
+    soaper = Soaper("1.1.1.1", 12345, "xxxunam", "xxxpwd")
+    actual_header = soaper.get_header(multi_factor_token = "abcdef<>\"\"")
+    expected_header = "<s:Header><avm:token xmlns:avm=\"avm.de\" s:mustUnderstand=\"1\">abcdef&lt;&gt;&quot;&quot;</avm:token></s:Header>"
+    assert actual_header == expected_header

--- a/fritzconnection/tests/test_soaper.py
+++ b/fritzconnection/tests/test_soaper.py
@@ -434,13 +434,13 @@ def test_redact_debug_log_wifi_passwords():
 
 def test_header_empty():
     """This case covers the situation where there is nothing to add into the header block."""
-    soaper = Soaper("1.1.1.1", 12345, "xxxunam", "xxxpwd")
+    soaper = Soaper("192.0.2.33", 12345, "xxxunam", "xxxpwd")
     actual_header = soaper.get_header(multi_factor_token = None)
     assert actual_header == ""
 
 def test_header_token():
     """This case covers the situation where there is nothing to add into the header block."""
-    soaper = Soaper("1.1.1.1", 12345, "xxxunam", "xxxpwd")
+    soaper = Soaper("192.0.2.33", 12345, "xxxunam", "xxxpwd")
     actual_header = soaper.get_header(multi_factor_token = "abcdef<>\"\"")
     expected_header = "<s:Header><avm:token xmlns:avm=\"avm.de\" s:mustUnderstand=\"1\">abcdef&lt;&gt;&quot;&quot;</avm:token></s:Header>"
     assert actual_header == expected_header


### PR DESCRIPTION
Some SOAP calls into the router require that a multi-factor token also be provided using a SOAP header. An example of such a header and documentation can be found [here](https://fritz.support/resources/TR-064_Authentication.pdf). As-built, the `fritzconnection` library provides no means to supply this additional header and so there's no way to use these actions.

This PR will introduce a means by which, on an action-call by action-call basis, these is a mechanism to supply the token and to consequently have the SOAP header added.