### PR TITLE
Add Web UI API base module and WireGuard VPN support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .Python
 .tox
 .nox
+.venv
 .pytest_cache
 .vscode/*
 *.ipynb*

--- a/docs/sources/library_modules.rst
+++ b/docs/sources/library_modules.rst
@@ -462,6 +462,29 @@ The call of the `get_wifi_qr_code()` method returns a file-like object. Instead 
     If the `segno`-package is not available, calling the method will raise an `AttributeError`. Refer to `Installation <install.html>`_ to install this requirement.
 
 
+FritzWebUI and FritzWireguard
+.............................
+
+WireGuard VPN connections are not exposed via TR-064/SOAP. ``FritzWebUI``
+handles Web UI login (PBKDF2 and legacy MD5, same as ``FritzHttp``).
+``FritzWireguard`` lists and toggles WireGuard connections (FRITZ!OS 7.50+).
+
+Example: ::
+
+    from fritzconnection import FritzConnection
+    from fritzconnection.lib.fritzwireguard import FritzWireguard
+
+    fc = FritzConnection(address="192.168.178.1", password=<password>)
+    fwg = FritzWireguard(fc)
+    fwg.toggle_vpn("uid-office", enable=False)
+
+.. automodule:: fritzconnection.lib.fritzwebui
+    :members:
+
+.. automodule:: fritzconnection.lib.fritzwireguard
+    :members:
+
+
 FritzWLAN API
 .............
 

--- a/fritzconnection/lib/fritzwebui.py
+++ b/fritzconnection/lib/fritzwebui.py
@@ -1,0 +1,258 @@
+"""
+Module for Fritz!Box Web UI API access (undocumented endpoints).
+"""
+# This module is part of the FritzConnection package.
+# https://github.com/kbr/fritzconnection
+# License: MIT (https://opensource.org/licenses/MIT)
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+import xml.etree.ElementTree as ET
+from http.client import HTTP_PORT
+from typing import Any
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, Timeout
+
+from ..core.fritzconnection import FritzConnection
+from .fritzbase import AbstractLibraryBase
+
+_LOGGER = logging.getLogger(__name__)
+
+API_LOGIN = "/login_sid.lua"
+API_DATA = "/data.lua"
+API_LOGIN_VERSION = "?version=2"
+AUTH_HEADER_PREFIX = "AVM-SID "
+
+DEFAULT_TIMEOUT = 10
+HTTP_STATUS_FORBIDDEN = 403
+INVALID_SID_VALUE = "0000000000000000"
+
+LOGIN_TAG_CHALLENGE = "Challenge"
+LOGIN_TAG_SID = "SID"
+LOGIN_TAG_BLOCKTIME = "BlockTime"
+
+LOGIN_FORM_USERNAME = "username"
+LOGIN_FORM_RESPONSE = "response"
+
+
+def _parse_challenge_from_login_xml(content: str) -> str | None:
+    try:
+        root = ET.fromstring(content)
+        challenge = root.find(LOGIN_TAG_CHALLENGE)
+        return challenge.text if challenge is not None else None
+    except ET.ParseError:
+        return None
+
+
+def _parse_sid_from_login_response(content: str) -> str | None:
+    try:
+        root = ET.fromstring(content)
+        sid = root.find(LOGIN_TAG_SID)
+        if sid is not None and sid.text and sid.text != INVALID_SID_VALUE:
+            return sid.text
+    except ET.ParseError:
+        pass
+    match = re.search(r'sid["\']?\s*[=:]\s*["\']?([0-9a-fA-F]{16})', content)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _parse_blocktime_from_login_xml(content: str) -> int | None:
+    try:
+        root = ET.fromstring(content)
+        blocktime = root.find(LOGIN_TAG_BLOCKTIME)
+        if blocktime is not None and blocktime.text:
+            return int(blocktime.text)
+    except (ET.ParseError, ValueError):
+        return None
+    return None
+
+
+def _calculate_pbkdf2_response(challenge: str, password: str) -> str | None:
+    """Same algorithm as FritzHttp._get_pbkdf2_hash."""
+    parts = challenge.split("$")
+    if len(parts) < 5 or parts[0] != "2":
+        return None
+    iter1 = int(parts[1])
+    salt1_hex = parts[2]
+    iter2 = int(parts[3])
+    salt2_hex = parts[4]
+    salt1 = bytes.fromhex(salt1_hex)
+    salt2 = bytes.fromhex(salt2_hex)
+    hash1 = hashlib.pbkdf2_hmac("sha256", password.encode(), salt1, iter1)
+    hash2 = hashlib.pbkdf2_hmac("sha256", hash1, salt2, iter2)
+    return f"{salt2_hex}${hash2.hex()}"
+
+
+def _calculate_md5_response(challenge: str, password: str) -> str:
+    response_raw = f"{challenge}-{password}".encode("utf-16le")
+    return f"{challenge}-{hashlib.md5(response_raw).hexdigest()}"
+
+
+class FritzWebUI(AbstractLibraryBase):
+    """
+    Base class for Fritz!Box Web UI API access.
+
+    Optional argument `fc` is a FritzConnection instance. Further
+    arguments are forwarded to FritzConnection.__init__() if `fc` is
+    not given.
+
+    WARNING: Web UI endpoints are undocumented by AVM and may change
+    without notice when the router OS is updated.
+    """
+
+    def __init__(self, fc: FritzConnection | None = None, *args, **kwargs) -> None:
+        super().__init__(fc, *args, **kwargs)
+        self._sid: str | None = None
+
+    @property
+    def _web_ui_port(self) -> int:
+        if self.fc.address.startswith("https"):
+            data = self.fc.call_action("X_AVM-DE_RemoteAccess1", "GetInfo")
+            return int(data["NewPort"])
+        return HTTP_PORT
+
+    @property
+    def _base_url(self) -> str:
+        return f"{self.fc.address}:{self._web_ui_port}"
+
+    def _ensure_sid(self) -> str | None:
+        if self._sid is not None:
+            return self._sid
+
+        username = self.fc.soaper.user
+        password = self.fc.soaper.password
+        if not password:
+            return None
+
+        sid = self._try_pbkdf2_login(username, password)
+        if sid is None:
+            sid = self._try_md5_login(username, password)
+        if sid is not None:
+            self._sid = sid
+        return sid
+
+    def _try_pbkdf2_login(self, username: str, password: str) -> str | None:
+        login_url = f"{self._base_url}{API_LOGIN}{API_LOGIN_VERSION}"
+        try:
+            response = self.fc.session.get(login_url, timeout=DEFAULT_TIMEOUT)
+            response.raise_for_status()
+            content = response.text
+        except (RequestsConnectionError, HTTPError, Timeout):
+            return None
+
+        challenge = _parse_challenge_from_login_xml(content)
+        if challenge is None or not challenge.startswith("2$"):
+            return None
+
+        blocktime = _parse_blocktime_from_login_xml(content)
+        if blocktime and blocktime > 0:
+            time.sleep(blocktime)
+
+        response_hash = _calculate_pbkdf2_response(challenge, password)
+        if response_hash is None:
+            return None
+
+        login_data = {
+            LOGIN_FORM_USERNAME: username,
+            LOGIN_FORM_RESPONSE: response_hash,
+        }
+        try:
+            response = self.fc.session.post(
+                login_url, data=login_data, timeout=DEFAULT_TIMEOUT
+            )
+            response.raise_for_status()
+            return _parse_sid_from_login_response(response.text)
+        except (RequestsConnectionError, HTTPError, Timeout):
+            return None
+
+    def _try_md5_login(self, username: str, password: str) -> str | None:
+        login_url = f"{self._base_url}{API_LOGIN}"
+        try:
+            response = self.fc.session.get(login_url, timeout=DEFAULT_TIMEOUT)
+            response.raise_for_status()
+            content = response.text
+        except (RequestsConnectionError, HTTPError, Timeout):
+            return None
+
+        challenge = _parse_challenge_from_login_xml(content)
+        if challenge is None:
+            return None
+
+        login_data = {
+            LOGIN_FORM_USERNAME: username,
+            LOGIN_FORM_RESPONSE: _calculate_md5_response(challenge, password),
+        }
+        try:
+            response = self.fc.session.post(
+                login_url, data=login_data, timeout=DEFAULT_TIMEOUT
+            )
+            response.raise_for_status()
+            return _parse_sid_from_login_response(response.text)
+        except (RequestsConnectionError, HTTPError, Timeout):
+            return None
+
+    def _request(
+        self,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        *,
+        method: str = "POST",
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if not self._ensure_sid():
+            return None
+
+        url = f"{self._base_url}{endpoint}"
+        headers = {"Accept": "application/json"}
+
+        try:
+            if method == "GET":
+                params = dict(data or {})
+                params["sid"] = self._sid
+                response = self.fc.session.get(
+                    url, params=params, headers=headers, timeout=DEFAULT_TIMEOUT
+                )
+            elif method == "PUT":
+                headers["Content-Type"] = "application/json"
+                if self._sid:
+                    headers["Authorization"] = f"{AUTH_HEADER_PREFIX}{self._sid}"
+                headers.setdefault("Origin", self.fc.address)
+                headers.setdefault("Referer", f"{self.fc.address}/")
+                response = self.fc.session.put(
+                    url, headers=headers, json=json_body, timeout=DEFAULT_TIMEOUT
+                )
+            else:
+                post_data = dict(data or {})
+                post_data["sid"] = self._sid
+                response = self.fc.session.post(
+                    url, data=post_data, headers=headers, timeout=DEFAULT_TIMEOUT
+                )
+
+            response.raise_for_status()
+            if not response.text.strip():
+                return {}
+            try:
+                return response.json()
+            except ValueError:
+                return None
+        except HTTPError as err:
+            if err.response is not None and err.response.status_code == HTTP_STATUS_FORBIDDEN:
+                self._sid = None
+                if self._ensure_sid():
+                    return self._request(endpoint, data, method=method, json_body=json_body)
+            return None
+        except (Timeout, RequestsConnectionError):
+            return None
+
+    def get_page_data(self, page: str) -> dict[str, Any] | None:
+        return self._request(API_DATA, {"page": page})
+
+    def invalidate_session(self) -> None:
+        self._sid = None

--- a/fritzconnection/lib/fritzwireguard.py
+++ b/fritzconnection/lib/fritzwireguard.py
@@ -1,0 +1,109 @@
+"""
+Module to access WireGuard VPN connections via the Fritz!Box Web UI API.
+"""
+# This module is part of the FritzConnection package.
+# https://github.com/kbr/fritzconnection
+# License: MIT (https://opensource.org/licenses/MIT)
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .fritzwebui import FritzWebUI
+
+_LOGGER = logging.getLogger(__name__)
+
+API_KEY_DATA = "data"
+API_KEY_INIT = "init"
+API_KEY_BOX_CONNECTIONS = "boxConnections"
+API_KEY_UID = "uid"
+API_KEY_ACTIVE = "active"
+API_KEY_ACTIVATED = "activated"
+API_KEY_CONNECTED = "connected"
+API_KEY_NAME = "name"
+
+API_PAGE_SHAREWIREGUARD = "shareWireguard"
+API_VPN_CONNECTION = "/api/v0/generic/vpn/connection/{uid}"
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+def _normalize_connection(data: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(data, dict):
+        return None
+    uid = data.get(API_KEY_UID)
+    if not uid:
+        return None
+    return {
+        API_KEY_UID: uid,
+        API_KEY_NAME: data.get(API_KEY_NAME, uid),
+        API_KEY_ACTIVE: _parse_bool(data.get(API_KEY_ACTIVE, False)),
+        API_KEY_ACTIVATED: _parse_bool(data.get(API_KEY_ACTIVATED, False)),
+        API_KEY_CONNECTED: _parse_bool(data.get(API_KEY_CONNECTED, False)),
+    }
+
+
+class FritzWireguard(FritzWebUI):
+    """
+    Class to list and toggle WireGuard VPN connections.
+
+    All parameters are optional. If given, they have the following
+    meaning: `fc` is an instance of FritzConnection, `address` the ip of
+    the Fritz!Box, `port` the port to connect to, `user` the username,
+    `password` the password, `timeout` a timeout as floating point number
+    in seconds, `use_tls` a boolean indicating to use TLS (default False).
+    """
+
+    def get_vpn_connections(self) -> dict[str, dict[str, Any]]:
+        """Return WireGuard VPN connections keyed by uid."""
+        response = self.get_page_data(API_PAGE_SHAREWIREGUARD)
+        if response is None:
+            return {}
+
+        try:
+            data = response.get(API_KEY_DATA, response)
+            init_data = data.get(API_KEY_INIT, {})
+            connections = init_data.get(API_KEY_BOX_CONNECTIONS)
+        except (AttributeError, TypeError):
+            return {}
+
+        if connections is None:
+            return {}
+
+        result: dict[str, dict[str, Any]] = {}
+        if isinstance(connections, dict):
+            for conn_data in connections.values():
+                normalized = _normalize_connection(conn_data)
+                if normalized is not None:
+                    result[normalized[API_KEY_UID]] = normalized
+        elif isinstance(connections, list):
+            for conn in connections:
+                normalized = _normalize_connection(conn)
+                if normalized is not None:
+                    result[normalized[API_KEY_UID]] = normalized
+        return result
+
+    def toggle_vpn(self, connection_uid: str, enable: bool) -> bool:
+        """
+        Enable or disable the VPN connection with the given uid.
+
+        Returns True if the active state matches `enable` after the call.
+        """
+        if self._request(
+            API_VPN_CONNECTION.format(uid=connection_uid),
+            method="PUT",
+            json_body={API_KEY_ACTIVATED: 1 if enable else 0},
+        ) is None:
+            return False
+
+        after = self.get_vpn_connections()
+        if connection_uid not in after:
+            return False
+        return after[connection_uid][API_KEY_ACTIVE] is enable

--- a/fritzconnection/tests/test_fritzwebui.py
+++ b/fritzconnection/tests/test_fritzwebui.py
@@ -1,0 +1,78 @@
+"""Tests for FritzWebUI module."""
+
+from unittest.mock import MagicMock
+
+from fritzconnection.lib.fritzwebui import (
+    FritzWebUI,
+    API_LOGIN,
+    API_DATA,
+    DEFAULT_TIMEOUT,
+    _parse_challenge_from_login_xml,
+    _parse_sid_from_login_response,
+    _calculate_pbkdf2_response,
+    _calculate_md5_response,
+)
+
+
+def _mock_fc(*, use_tls: bool = True) -> MagicMock:
+    mock_fc = MagicMock()
+    mock_fc.address = "https://192.168.178.1" if use_tls else "http://192.168.178.1"
+    mock_fc.port = 49443 if use_tls else 49000
+    mock_fc.soaper.user = "admin"
+    mock_fc.soaper.password = "password"
+    if use_tls:
+        mock_fc.call_action.return_value = {"NewPort": 443}
+    return mock_fc
+
+
+def test_module_imports():
+    assert API_LOGIN == "/login_sid.lua"
+    assert API_DATA == "/data.lua"
+    assert DEFAULT_TIMEOUT == 10
+
+
+def test_fritzwebui_base_url():
+    assert FritzWebUI(fc=_mock_fc())._base_url == "https://192.168.178.1:443"
+    assert FritzWebUI(fc=_mock_fc(use_tls=False))._base_url == "http://192.168.178.1:80"
+
+
+def test_parse_challenge_from_login_xml():
+    xml = '<?xml version="1.0"?><SessionInfo><Challenge>12345abc</Challenge></SessionInfo>'
+    assert _parse_challenge_from_login_xml(xml) == "12345abc"
+
+
+def test_parse_challenge_invalid_xml():
+    assert _parse_challenge_from_login_xml("not xml") is None
+
+
+def test_parse_sid_from_xml():
+    xml = '<?xml version="1.0"?><SessionInfo><SID>1234567890abcdef</SID></SessionInfo>'
+    assert _parse_sid_from_login_response(xml) == "1234567890abcdef"
+
+
+def test_parse_sid_from_html():
+    html = '<html>sid: 1234567890abcdef</html>'
+    assert _parse_sid_from_login_response(html) == "1234567890abcdef"
+
+
+def test_parse_sid_invalid():
+    xml = '<?xml version="1.0"?><SessionInfo><SID>0000000000000000</SID></SessionInfo>'
+    assert _parse_sid_from_login_response(xml) is None
+
+
+def test_calculate_md5_response():
+    response = _calculate_md5_response("12345", "testpass")
+    assert response.startswith("12345-")
+    assert len(response.split("-", 1)[1]) == 32
+
+
+def test_calculate_pbkdf2_response():
+    challenge = "2$10000$abcd1234$10000$ef567890"
+    response = _calculate_pbkdf2_response(challenge, "testpass")
+    assert response is not None
+    assert response.startswith("ef567890$")
+    assert len(response.split("$", 1)[1]) == 64
+
+
+def test_calculate_pbkdf2_invalid():
+    assert _calculate_pbkdf2_response("invalid", "password") is None

--- a/fritzconnection/tests/test_fritzwireguard.py
+++ b/fritzconnection/tests/test_fritzwireguard.py
@@ -1,0 +1,127 @@
+"""Tests for FritzWireguard module."""
+
+from unittest.mock import MagicMock, patch
+
+from fritzconnection.lib.fritzwireguard import (
+    FritzWireguard,
+    API_KEY_ACTIVE,
+    API_KEY_NAME,
+    API_KEY_UID,
+)
+from fritzconnection.lib.fritzwebui import FritzWebUI
+
+
+def _mock_fc() -> MagicMock:
+    mock_fc = MagicMock()
+    mock_fc.address = "https://192.168.178.1"
+    mock_fc.port = 49443
+    mock_fc.soaper.user = "admin"
+    mock_fc.soaper.password = "password"
+    mock_fc.call_action.return_value = {"NewPort": 443}
+    return mock_fc
+
+
+def test_module_constants():
+    assert API_KEY_ACTIVE == "active"
+    assert API_KEY_NAME == "name"
+    assert API_KEY_UID == "uid"
+
+
+def test_fritzwireguard_inherits_fritzwebui():
+    fw = FritzWireguard(fc=_mock_fc())
+    assert isinstance(fw, FritzWebUI)
+
+
+def test_get_vpn_connections_empty():
+    fw = FritzWireguard(fc=_mock_fc())
+    with patch.object(fw, "get_page_data", return_value=None):
+        assert fw.get_vpn_connections() == {}
+
+
+def test_get_vpn_connections_with_list_data():
+    fw = FritzWireguard(fc=_mock_fc())
+    mock_response = {
+        "data": {
+            "init": {
+                "boxConnections": [
+                    {
+                        "uid": "uid-office",
+                        "name": "Office",
+                        "active": True,
+                        "activated": True,
+                        "connected": True,
+                    }
+                ]
+            }
+        }
+    }
+    with patch.object(fw, "get_page_data", return_value=mock_response):
+        connections = fw.get_vpn_connections()
+        assert connections["uid-office"]["name"] == "Office"
+        assert connections["uid-office"]["active"] is True
+
+
+def test_get_vpn_connections_with_dict_data():
+    fw = FritzWireguard(fc=_mock_fc())
+    mock_response = {
+        "init": {
+            "boxConnections": {
+                "wg-1": {
+                    "uid": "wg-1",
+                    "name": "Remote",
+                    "active": "1",
+                    "activated": False,
+                    "connected": "0",
+                }
+            }
+        }
+    }
+    with patch.object(fw, "get_page_data", return_value=mock_response):
+        connections = fw.get_vpn_connections()
+        assert connections["wg-1"]["active"] is True
+        assert connections["wg-1"]["connected"] is False
+
+
+def test_get_vpn_connections_malformed():
+    fw = FritzWireguard(fc=_mock_fc())
+    with patch.object(fw, "get_page_data", return_value={"invalid": "data"}):
+        assert fw.get_vpn_connections() == {}
+
+
+def test_toggle_vpn_success():
+    fw = FritzWireguard(fc=_mock_fc())
+    after = {
+        "uid-office": {
+            API_KEY_UID: "uid-office",
+            API_KEY_NAME: "Office",
+            API_KEY_ACTIVE: True,
+        }
+    }
+    with patch.object(fw, "get_vpn_connections", return_value=after):
+        with patch.object(fw, "_request", return_value={}) as mock_request:
+            assert fw.toggle_vpn("uid-office", enable=True) is True
+            mock_request.assert_called_once_with(
+                "/api/v0/generic/vpn/connection/uid-office",
+                method="PUT",
+                json_body={"activated": 1},
+            )
+
+
+def test_toggle_vpn_none_response():
+    fw = FritzWireguard(fc=_mock_fc())
+    with patch.object(fw, "_request", return_value=None):
+        assert fw.toggle_vpn("uid-office", enable=False) is False
+
+
+def test_toggle_vpn_verify_mismatch():
+    fw = FritzWireguard(fc=_mock_fc())
+    after = {
+        "uid-office": {
+            API_KEY_UID: "uid-office",
+            API_KEY_NAME: "Office",
+            API_KEY_ACTIVE: False,
+        }
+    }
+    with patch.object(fw, "get_vpn_connections", return_value=after):
+        with patch.object(fw, "_request", return_value={}):
+            assert fw.toggle_vpn("uid-office", enable=True) is False


### PR DESCRIPTION
# Add Web UI API base module and WireGuard VPN support

## Motivation

WireGuard VPN (FRITZ!OS 7.50+) is not available via TR-064/SOAP. It is only reachable through the Fritz!Box Web UI HTTP API (same endpoints as the web interface).

This PR adds a reusable Web UI base class and WireGuard helpers so downstream projects can use **one** `FritzConnection` session (no extra PyPI client, no parallel login storms on the box).

## Home Assistant context

There is an existing **[HACS custom integration FRITZ!Box VPN](https://github.com/rosch100/fritzbox-vpn)** (switches, status sensors, diagnostics) that proved the Web UI API in production.

The follow-up goal is to bring WireGuard on/off into **[FRITZ!Box Tools](https://www.home-assistant.io/integrations/fritz/)** (`fritz` integration) instead of a separate domain — as suggested by [@mib1185](https://github.com/mib1185) (FRITZ!Box Tools code owner) in [home-assistant/core#171459](https://github.com/home-assistant/core/pull/171459#pullrequestreview-4331261008):

- implement VPN access in **`fritzconnection`** (this PR),
- reuse the existing config entry and connection,
- avoid a separate coordinator and extra dependency.

A planned Home Assistant core change builds on this library once released; HACS can remain for extended sensors beyond core switches.

## Web UI vs TR-064

| Aspect | TR-064 | Web UI |
|--------|--------|--------|
| Protocol | SOAP over HTTP | HTTP REST |
| Auth | HTTP Digest | SID challenge-response (PBKDF2 or MD5) |
| Coverage | Most legacy features | Newer features (WireGuard, …) |

## Implementation notes

- **HTTPS port:** from TR-064 `GetInfo` → `NewPort` (not the TR-064 control port).
- **Auth:** `Authorization: AVM-SID {sid}`; PBKDF2 aligned with `FritzHttp`.
- **Session:** HTTP requests use `FritzConnection.session`.
- **Toggle:** `PUT /api/v0/generic/vpn/connection/{uid}` with body `{"activated": 0|1}`.

**FritzWebUI:** login, session, `get_page_data`, generic `_request`.

**FritzWireguard:** `get_vpn_connections()`, `toggle_vpn(uid, enable)`.

## Usage

```python
from fritzconnection import FritzConnection
from fritzconnection.lib.fritzwireguard import FritzWireguard

fc = FritzConnection(address="192.168.178.1", password="…")
fwg = FritzWireguard(fc)
fwg.toggle_vpn("uid-office", enable=False)
```

## Files

| File | Purpose |
|------|---------|
| `fritzwebui.py` | Base Web UI class |
| `fritzwireguard.py` | WireGuard list/toggle |
| `test_fritzwebui.py` / `test_fritzwireguard.py` | Unit tests |
| `docs/sources/library_modules.rst` | Sphinx module docs |

## Backward compatibility

- No changes to existing modules
- No new dependencies
- Optional import for WireGuard users only
