### PR TITLE
Fix duplicate test id for pytest-9

### DIFF
--- a/fritzconnection/tests/test_core_utils.py
+++ b/fritzconnection/tests/test_core_utils.py
@@ -66,7 +66,7 @@ def test_boolean_from_string_typeerror(value):
         ("None", None),
         (42, None),
         ("", None),
-        (None, None),
+        pytest.param(None, None, id="(None)-None"),
     ]
 )
 def test_get_boolean_from_string(value, expected_result):


### PR DESCRIPTION
Running the test suite using pytest-9 yields the following error:

```
______________________________________ ERROR collecting fritzconnection/tests/test_core_utils.py ______________________________________
Duplicate parametrization IDs detected, but strict_parametrization_ids is set.

Test name:      fritzconnection/tests/test_core_utils.py::test_get_boolean_from_string
Parameters:     value, expected_result
Parameter sets: ['true', True], ['false', False], ['wahr', None], ['falsch', None], ['None', None], [42, None], ['', None], [None, None]
IDs:            true-True, false-False, wahr-None, falsch-None, None-None, 42-None, -None, None-None
Duplicates:     None-None

You can fix this problem using `@pytest.mark.parametrize(..., ids=...)` or `pytest.param(..., id=...)`.
```

This is because both `"None"` and `None` resolve to the same identifier. Override the identifier for the latter to fix the test suite.